### PR TITLE
docs: point folder READMEs to the just bootstrap

### DIFF
--- a/dotfiles/README.md
+++ b/dotfiles/README.md
@@ -19,14 +19,21 @@ máquina ficam em `~/.zshrc.local` (não versionado).
 
 ## Como instalar (máquina nova)
 
-Faça `~/.zshrc` apontar para o arquivo deste repo (symlink mantém tudo em sync):
+A forma recomendada é o bootstrap do repo (ver [README raiz](../README.md)), que
+symlinka os configs compartilhados e faz o *seed* dos templates com segredo
+(`.gitconfig`, `.wakatime.cfg`, `~/.zshrc.local`) **só se não existirem**:
+
+```sh
+just link    # symlinka .zshrc, .gitignore.global, .opentofurc (+ starship, nvim, mise)
+just seed    # copia os templates de identidade/segredo, se faltarem
+# ou, de uma vez:  just bootstrap
+```
+
+Fallback manual (equivalente, sem o `just`):
 
 ```sh
 ln -sfn "$(pwd)/dotfiles/.zshrc" ~/.zshrc
 cp dotfiles/.zshrc.local.example ~/.zshrc.local   # depois preencha os segredos
 ```
 
-Os demais dotfiles podem ser symlinkados para a home da mesma forma, conforme a
-necessidade (ex.: `.gitconfig`, `.wakatime.cfg`).
-
-> Em máquina já configurada, o `~/.zshrc` aqui é symlink para este arquivo — ver o README raiz.
+> Numa máquina já configurada, `~/.zshrc` é symlink para este arquivo.

--- a/nvim/README.md
+++ b/nvim/README.md
@@ -9,8 +9,8 @@ Pré-requisitos: Neovim ≥ 0.11, `git`, `ripgrep`, `fd`, um compilador C (Xcode
 e os toolchains via **mise** (`go`, `java`, `kotlin`, `node`, `dotnet`). Passo a passo em `SETUP.md`.
 
 ```sh
-# A partir da raiz do big-bang, aponte ~/.config/nvim para esta pasta:
-ln -sfn "$(pwd)/nvim" ~/.config/nvim
+just link    # symlinka ~/.config/nvim para esta pasta (entre os demais configs)
+# fallback manual:  ln -sfn "$(pwd)/nvim" ~/.config/nvim
 ```
 
 No primeiro `nvim`, o **lazy.nvim** instala os plugins e o **Mason** instala os

--- a/starship/README.md
+++ b/starship/README.md
@@ -14,6 +14,8 @@ Com o Starship ativo, o tema do oh-my-zsh fica desligado (`ZSH_THEME=""`).
 ## Instalação (máquina nova)
 
 ```sh
-brew install starship
-ln -sfn "$(pwd)/starship/starship.toml" ~/.config/starship.toml
+just brew    # instala o starship (via Brewfile)
+just link    # symlinka ~/.config/starship.toml para esta pasta
+# fallback manual:
+#   brew install starship && ln -sfn "$(pwd)/starship/starship.toml" ~/.config/starship.toml
 ```


### PR DESCRIPTION
Follow-up to the bootstrap/CI PR. The `dotfiles/`, `nvim/` and `starship/` folder
READMEs still showed manual `ln -sfn` install steps and didn't mention `just`.

They now reference `just link` / `just bootstrap` as the primary method, keeping
the manual `ln` as a fallback — so each folder's doc is consistent with the root README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)