### PR TITLE
feat: Claude setup automation + WezTerm split keybindings (managed)

### DIFF
--- a/.claude/commands/setup-machine.md
+++ b/.claude/commands/setup-machine.md
@@ -1,0 +1,17 @@
+---
+description: Configura ESTA máquina (macOS) do zero a partir do repo — bootstrap, segredos e validação
+---
+Prepare ESTA máquina usando este repositório como fonte de verdade, seguindo a
+skill **machine-bootstrap**. Confirme cada passo destrutivo antes de executar e
+**não invente segredos** — peça os valores ao usuário.
+
+Resumo do fluxo (a skill tem o detalhe):
+
+1. Garanta Homebrew e `just` (`brew install just`); instale o Homebrew se faltar.
+2. `just bootstrap` — instala o `@Brewfile`, symlinka os configs (com backup),
+   roda `mise install` e faz o *seed* dos templates.
+3. Identidade/segredos: git `user.name/email/signingkey`; `~/.zshrc.local`
+   (ver `@dotfiles/.zshrc.local.example`); WakaTime via `:WakaTimeApiKey` no nvim.
+4. `gh auth login` é interativo — peça ao usuário rodar `! gh auth login --git-protocol ssh --web`.
+5. Valide com `just doctor`, abra o `nvim` pra disparar plugins/LSP e confira o starship numa shell nova.
+6. Resuma o que ficou pronto e o que ainda depende do usuário.

--- a/.claude/commands/sync.md
+++ b/.claude/commands/sync.md
@@ -1,0 +1,11 @@
+---
+description: Re-sincroniza a máquina com o repo (symlinks + Brewfile) e reporta divergências
+---
+Sincronize ESTA máquina com o repositório:
+
+1. `just link` — reaplica os symlinks (idempotente; faz backup do que for arquivo real).
+2. `just doctor` — confira ferramentas no PATH e symlinks resolvidos.
+3. `brew bundle check --file=Brewfile` — veja se falta instalar algo do `@Brewfile`.
+   Se o usuário instalou algo novo que deveria ser versionado, sugira `just brew-dump`.
+4. Reporte qualquer divergência entre a home e o repo (ex.: arquivos que deixaram de
+   ser symlink, ou configs editados só localmente).

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(just:*)",
+      "Bash(brew bundle:*)",
+      "Bash(brew install:*)",
+      "Bash(brew list:*)",
+      "Bash(mise:*)",
+      "Bash(stylua:*)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)"
+    ]
+  }
+}

--- a/.claude/skills/machine-bootstrap/SKILL.md
+++ b/.claude/skills/machine-bootstrap/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: machine-bootstrap
+description: Use quando o usuário quiser configurar/preparar uma máquina nova (macOS) a partir deste repositório de dotfiles, fazer o bootstrap do ambiente, reinstalar o setup ou re-sincronizar os configs. Cobre Homebrew, just, mise, symlinks, segredos e validação.
+---
+
+# Bootstrap de máquina (macOS) com o Big Bang
+
+Este repositório é a fonte de verdade do ambiente. O objetivo é deixar uma máquina
+nova pronta com o mínimo de esforço, sem expor segredos.
+
+## Princípios
+- **Nunca invente nem commite segredos.** Identidade/credenciais vão para
+  `~/.zshrc.local` (gitignored) — peça os valores ao usuário.
+- `just link` symlinka os configs compartilhados (faz backup do que for arquivo real).
+- `just seed` copia templates de identidade/segredo **só se não existirem**.
+- Confirme passos destrutivos antes de rodar.
+
+## Passos
+
+1. **Pré-requisitos**
+   - Homebrew instalado? Se não, instale (`/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`).
+   - `brew install just`
+
+2. **Bootstrap** (na raiz do repo)
+   - `just bootstrap` = `brew` (instala o Brewfile) → `link` → `mise-install` → `seed`.
+   - Se algo falhar, rode as recipes individuais (`just brew`, `just link`, etc.) e investigue.
+
+3. **Identidade e segredos** (peça ao usuário; não preencha sozinho)
+   - Git: `git config --global user.name`, `user.email`, `user.signingkey` (assinatura GPG está ligada no `.gitconfig`).
+   - `~/.zshrc.local`: `AWS_*`, `GITHUB_TOKEN`, `EKS_PRD_ARN`, `EKS_HML_ARN` — modelo em `dotfiles/.zshrc.local.example`.
+   - WakaTime: dentro do `nvim`, `:WakaTimeApiKey` (chave em https://wakatime.com/settings/api-key).
+
+4. **Autenticações interativas** (não dá pra rodar headless)
+   - `gh auth login` — peça ao usuário rodar com `! gh auth login --git-protocol ssh --web`.
+
+5. **Validação**
+   - `just doctor` — ferramentas no PATH + symlinks resolvidos.
+   - Abra o `nvim` uma vez: o lazy.nvim instala os plugins e o Mason os LSPs/formatadores.
+   - Abra uma shell nova: confira o prompt do **starship** e os aliases (`vim`→nvim, `ls`→eza).
+
+6. **Fechamento**
+   - Resuma o que ficou pronto e o que ainda depende do usuário (segredos, GPG, etc.).
+   - Se o usuário tiver instalado ferramentas novas que deveriam ser versionadas, sugira `just brew-dump`.
+
+## Manutenção (máquina já configurada)
+- `just link` reaplica symlinks · `just doctor` checa estado · `just brew` atualiza pacotes.
+- PRs: `just pr`. Nunca push direto na `main`.

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 # Segredos / config local da máquina (nunca commitar)
 .zshrc.local
 *.local
+
+# Claude Code — overrides pessoais (settings.json compartilhado é versionado)
+.claude/settings.local.json

--- a/Brewfile
+++ b/Brewfile
@@ -28,5 +28,6 @@ brew "kubernetes-cli"  # kubectl
 brew "opentofu"
 brew "ansible"         # ad-hoc only; remove if you don't use it
 
-# --- Fonts (used by WezTerm) ---
+# --- Terminal & fonts ---
+cask "wezterm"
 cask "font-hack-nerd-font"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,26 @@
+# Big Bang — guia para o Claude
+
+Repositório de **dotfiles / configuração de máquina (macOS)**. É a fonte de verdade
+do meu ambiente; o setup é feito com [`just`](./justfile) (sem provisionador pesado).
+
+## Estrutura
+- `dotfiles/` — dotfiles da home (templates, **sem segredos**)
+- `nvim/` — Neovim como IDE (Go/.NET/Kotlin); detalhes em `nvim/SETUP.md`
+- `wezterm/`, `starship/`, `mise/` — terminal, prompt e toolchains
+- `Brewfile` — pacotes Homebrew · `justfile` — bootstrap/manutenção
+- `.github/workflows/ci.yml` — CI (lint + gitleaks)
+
+## Convenções (importante)
+- **Nunca commitar segredos.** Credenciais/identidade vivem em `~/.zshrc.local`
+  (gitignored); template em `dotfiles/.zshrc.local.example`.
+- Configs são **symlinkados** para a home com `just link` (faz backup do que for
+  arquivo real). Editar no repo reflete na máquina, e vice-versa.
+- Templates com identidade/segredo (`.gitconfig`, `.wakatime.cfg`) são copiados
+  **só se não existirem** via `just seed` — nunca sobrescreva-os.
+- O Lua de `nvim/` é formatado com `stylua` (o CI checa). Rode `stylua nvim/` antes de commitar.
+- **Não dê push direto na `main`.** Trabalhe em branch e abra PR com `just pr` (usa o `gh`).
+
+## Setup de máquina nova
+Use o comando **`/setup-machine`** (ou deixe a skill *machine-bootstrap* guiar). Em resumo:
+`brew install just` → `just bootstrap` → preencher segredos/identidade → `gh auth login`
+→ validar com `just doctor`.

--- a/justfile
+++ b/justfile
@@ -31,6 +31,7 @@ link:
     just _link "{{ repo }}/starship/starship.toml"     "{{ home }}/.config/starship.toml"
     just _link "{{ repo }}/nvim"                        "{{ home }}/.config/nvim"
     just _link "{{ repo }}/mise/config.toml"           "{{ home }}/.config/mise/config.toml"
+    just _link "{{ repo }}/wezterm/.wezterm.lua"       "{{ home }}/.config/wezterm/wezterm.lua"
 
 # Seed template files that hold identity/secrets — only if missing (never clobbers)
 seed:

--- a/wezterm/.wezterm.lua
+++ b/wezterm/.wezterm.lua
@@ -64,7 +64,7 @@ config.keys = {
   -- Limpar terminal (como no iTerm)
   { key = "k", mods = "CMD", action = act.ClearScrollback("ScrollbackAndViewport") },
 
-  -- Splits
+  -- Splits:  CMD+Enter = pane novo EMBAIXO (em cima/baixo) · CMD+Shift+Enter = pane novo À DIREITA (lado a lado)
   { key = "Enter", mods = "CMD", action = act.SplitVertical({}) },
   { key = "Enter", mods = "CMD|SHIFT", action = act.SplitHorizontal({}) },
   { key = "w", mods = "CMD", action = act.CloseCurrentPane({ confirm = false }) },

--- a/wezterm/README.md
+++ b/wezterm/README.md
@@ -22,10 +22,11 @@ O WezTerm procura a configuração, nesta ordem:
 2. `~/.wezterm.lua`
 3. `~/.config/wezterm/wezterm.lua`
 
-Para usar o arquivo deste repositório, crie um symlink para um desses caminhos. Exemplo:
+A forma recomendada é o `just link` (na raiz do repo), que symlinka este arquivo
+para `~/.config/wezterm/wezterm.lua`. Manualmente:
 
 ```bash
-ln -sf "$PWD/wezterm/.wezterm.lua" ~/.wezterm.lua
+ln -sfn "$PWD/wezterm/.wezterm.lua" ~/.config/wezterm/wezterm.lua
 ```
 
 > Depois de editar a config, é só salvar — o WezTerm recarrega automaticamente.
@@ -86,8 +87,8 @@ ln -sf "$PWD/wezterm/.wezterm.lua" ~/.wezterm.lua
 ### Panes (divisões da tela)
 | Atalho | Ação |
 |---|---|
-| `CMD + Enter` | Divide na vertical (novo pane ao lado) |
-| `CMD + Shift + Enter` | Divide na horizontal (novo pane abaixo) |
+| `CMD + Enter` | Split em cima/embaixo (`SplitVertical` — novo pane **abaixo**) |
+| `CMD + Shift + Enter` | Split lado a lado (`SplitHorizontal` — novo pane **à direita**) |
 | `CMD + W` | Fecha o pane atual |
 | `CMD + setas` | Move o foco entre panes |
 | `CMD + Ctrl + setas` | Redimensiona o pane atual |


### PR DESCRIPTION
Two things:

### 1. Claude setup automation
So a new machine with Claude installed can drive the full setup from this repo:
- `CLAUDE.md` — project context + conventions
- `.claude/commands/setup-machine.md` (`/setup-machine`) and `sync.md` (`/sync`)
- `.claude/skills/machine-bootstrap/SKILL.md` — auto-invoked bootstrap procedure
- `.claude/settings.json` — scoped allow-list; `.claude/settings.local.json` gitignored

### 2. WezTerm split keybindings (now managed + documented correctly)
The `Cmd+Enter` / `Cmd+Shift+Enter` split bindings already existed but the config
wasn't tracked by the bootstrap and the README had the directions backwards.
- `just link` now symlinks `~/.config/wezterm/wezterm.lua` to the repo
- `cask "wezterm"` added to the Brewfile
- README fixed: **Cmd+Enter** = split below (`SplitVertical`); **Cmd+Shift+Enter** = split right (`SplitHorizontal`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)