### PR TITLE
fix(mise): trust repo config no bootstrap

### DIFF
--- a/.claude/commands/setup-machine.md
+++ b/.claude/commands/setup-machine.md
@@ -9,7 +9,7 @@ Resumo do fluxo (a skill tem o detalhe):
 
 1. Garanta Homebrew e `just` (`brew install just`); instale o Homebrew se faltar.
 2. `just bootstrap` — instala o `@Brewfile`, symlinka os configs (com backup),
-   roda `mise install` e faz o *seed* dos templates.
+   confia e instala as toolchains do `mise` (`mise trust` + `mise install`) e faz o *seed* dos templates.
 3. Identidade/segredos: git `user.name/email/signingkey`; `~/.zshrc.local`
    (ver `@dotfiles/.zshrc.local.example`); WakaTime via `:WakaTimeApiKey` no nvim.
 4. `gh auth login` é interativo — peça ao usuário rodar `! gh auth login --git-protocol ssh --web`.

--- a/.claude/skills/machine-bootstrap/SKILL.md
+++ b/.claude/skills/machine-bootstrap/SKILL.md
@@ -23,6 +23,9 @@ nova pronta com o mínimo de esforço, sem expor segredos.
 
 2. **Bootstrap** (na raiz do repo)
    - `just bootstrap` = `brew` (instala o Brewfile) → `link` → `mise-install` → `seed`.
+   - `mise-install` já roda `mise trust` no `mise/config.toml` do repo, então entrar na
+     pasta não dispara o erro de config não confiada. Se mesmo assim aparecer
+     `Config files ... are not trusted`, rode `mise trust mise/config.toml`.
    - Se algo falhar, rode as recipes individuais (`just brew`, `just link`, etc.) e investigue.
 
 3. **Identidade e segredos** (peça ao usuário; não preencha sozinho)

--- a/justfile
+++ b/justfile
@@ -21,6 +21,8 @@ brew:
 
 # Install the toolchains pinned in mise/config.toml
 mise-install:
+    # Trust the repo config so entering the repo dir doesn't error on an untrusted file
+    mise trust "{{ repo }}/mise/config.toml"
     mise install
 
 # Symlink shared, secret-free configs into place (idempotent; backs up real files)


### PR DESCRIPTION
Ao entrar na pasta do repo, o mise tentava carregar mise/config.toml como
config local e abortava com "Config files ... are not trusted". O recipe
mise-install agora roda `mise trust` no config antes do install, então uma
máquina nova já fica confiando no arquivo. Docs (skill + command) atualizados.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
