### PR TITLE
feat(theme): unifica wezterm e starship em Tokyo Night

### DIFF
--- a/starship/starship.toml
+++ b/starship/starship.toml
@@ -1,3 +1,17 @@
+# Tema: Tokyo Night (night) — alinhado com nvim (tokyonight) e wezterm.
+# Sobrescreve os nomes ANSI (blue/green/yellow/red) usados nos módulos abaixo
+# pelos hex exatos do Tokyo Night, então o prompt fica idêntico em qualquer terminal.
+palette = "tokyonight"
+
+[palettes.tokyonight]
+blue = "#7aa2f7"
+cyan = "#7dcfff"
+green = "#9ece6a"
+yellow = "#e0af68"
+orange = "#ff9e64"
+red = "#f7768e"
+purple = "#bb9af7"
+
 [aws]
 disabled = true
 symbol = "  "
@@ -177,7 +191,7 @@ Void = " "
 Windows = "󰍲 "
 
 [package]
-format = 'via [󰏗 $version](208 bold) '
+format = 'via [󰏗 $version](orange bold) '
 
 [perl]
 symbol = " "

--- a/wezterm/.wezterm.lua
+++ b/wezterm/.wezterm.lua
@@ -14,7 +14,7 @@ config.adjust_window_size_when_changing_font_size = false
 -- ===========================================================================
 -- Aparência
 -- ===========================================================================
-config.color_scheme = "Catppuccin Mocha"
+config.color_scheme = "Tokyo Night"
 config.window_background_opacity = 0.95
 -- Desfoca o que está atrás da janela transparente (fica bem melhor no macOS).
 config.macos_window_background_blur = 20


### PR DESCRIPTION
Alinha o tema das ferramentas com o nvim (que já usa tokyonight):
- wezterm: color_scheme Catppuccin Mocha -> Tokyo Night
- starship: adiciona palette tokyonight (sobrescreve blue/green/yellow/red
  pelos hex do tema) e troca o 208 fixo do módulo package por orange

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
