### PR TITLE
feat(brew): add VSCode, podman, google-drive, bruno, studio-3t

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -31,3 +31,6 @@ brew "ansible"         # ad-hoc only; remove if you don't use it
 # --- Terminal & fonts ---
 cask "wezterm"
 cask "font-hack-nerd-font"
+
+# --- Apps ---
+cask "visual-studio-code"  # instala também o CLI `code` no PATH

--- a/Brewfile
+++ b/Brewfile
@@ -27,6 +27,7 @@ brew "awscli"
 brew "kubernetes-cli"  # kubectl
 brew "opentofu"
 brew "ansible"         # ad-hoc only; remove if you don't use it
+brew "podman"          # container engine (Mac: roda via `podman machine`)
 
 # --- Terminal & fonts ---
 cask "wezterm"
@@ -34,3 +35,6 @@ cask "font-hack-nerd-font"
 
 # --- Apps ---
 cask "visual-studio-code"  # instala também o CLI `code` no PATH
+cask "google-drive"        # Google Drive (sync)
+cask "bruno"               # client de API (alternativa a Insomnia/Postman)
+cask "studio-3t"           # GUI de MongoDB (Studio 3T Free/Community)


### PR DESCRIPTION
Adiciona apps e ferramentas ao Brewfile (fonte de verdade do ambiente).

## O que entra
**Cloud / infra**
- `podman` — engine de container (CLI; no Mac roda via `podman machine`)

**Apps (casks)**
- `visual-studio-code` — instala também o CLI `code` no PATH (não precisa de alias)
- `google-drive`
- `bruno` — client de API (alternativa a Insomnia/Postman)
- `studio-3t` — GUI de MongoDB (Free/Community é o mesmo app)

`awscli` já estava no Brewfile.

## Nota de instalação
Esta é uma máquina gerenciada: `/Applications` é owned by root, então
instalar **casks de app GUI** via `just brew` pede senha de `sudo` interativa.
`podman` (formula CLI) instala sem sudo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)