### PR TITLE
feat(claude): add ruflo plugin via just recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ just link       # re-apply symlinks
 just brew       # install/upgrade Brewfile packages
 just brew-dump  # update the Brewfile from what's installed
 just doctor     # check tools + symlinks
+just ruflo      # install the ruflo Claude Code plugin (needs the `claude` CLI)
 ```
 
 ## Secrets

--- a/justfile
+++ b/justfile
@@ -65,6 +65,14 @@ doctor:
 pr:
     gh pr create --web --fill
 
+# Standalone (not in `bootstrap`): depends on the `claude` CLI, which this repo
+# doesn't manage. Idempotent; user scope, so it applies to every project.
+# Install the ruflo Claude Code plugin — multi-agent orchestration (slash commands)
+ruflo:
+    claude plugin marketplace add ruvnet/ruflo
+    claude plugin install ruflo-core@ruflo --scope user
+    @echo "→ ruflo-core installed (user scope). New skills/agents load next Claude Code session."
+
 # --- internal helpers (hidden from --list) ---
 
 # Symlink src -> dst, backing up an existing real file


### PR DESCRIPTION
## O quê

Adiciona uma recipe `just ruflo` que registra o marketplace `ruflo` e instala o plugin leve **`ruflo-core`** do Claude Code (multi-agent orchestration via slash commands), em **user scope**.

## Por quê

Tornar o ruflo parte reprodutível do setup de máquina, sem comprometer a filosofia enxuta do repo.

## Decisões

- **Fora do `bootstrap`**: a recipe depende do `claude` CLI, que este repo não gerencia (`~/.local/bin`). Forçar no bootstrap quebraria a idempotência em máquina sem o `claude`.
- **Plugin leve, não a CLI pesada**: só slash commands/skills/agents. Sem daemon em background, sem chaves multi-provider, sem federação.
- Comandos idempotentes (re-rodar não quebra).

## Verificação

- `just --list` mostra a recipe com descrição correta.
- `just ruflo` roda idempotente (marketplace + install já presentes → exit 0).
- `ruflo doctor`: 9 passed / 8 warnings — warnings são features pesadas (corretamente) desligadas.

## Arquivos

- `justfile` — nova recipe `ruflo`
- `README.md` — linha na lista de recipes

🤖 Generated with [Claude Code](https://claude.com/claude-code)