### PR TITLE
feat(zsh): auto-update do Homebrew 1x/dia em background

### DIFF
--- a/dotfiles/.zshrc
+++ b/dotfiles/.zshrc
@@ -183,6 +183,22 @@ setopt SHARE_HISTORY             # Share history between all sessions.
 export PATH="/opt/homebrew/bin:$PATH"
 eval $(/opt/homebrew/bin/brew shellenv)
 
+## Auto-update do Homebrew — no máx. 1x/dia, em background (não trava o prompt).
+## Só fórmulas: cask em Mac gerenciado pede sudo e travaria em background.
+## Log: ~/.cache/brew-autoupdate.log
+_brew_autoupdate() {
+    local stamp="${XDG_CACHE_HOME:-$HOME/.cache}/brew-autoupdate.stamp"
+    local log="${XDG_CACHE_HOME:-$HOME/.cache}/brew-autoupdate.log"
+    mkdir -p "${stamp:h}"
+    if [[ -f "$stamp" ]]; then
+        local last=$(stat -f %m "$stamp" 2>/dev/null || echo 0)
+        (( $(date +%s) - last < 86400 )) && return   # rodou há menos de 24h
+    fi
+    touch "$stamp"   # marca o slot já, pra abas paralelas não dispararem juntas
+    ( brew update && brew upgrade --formula && brew cleanup ) >"$log" 2>&1 &!
+}
+command -v brew >/dev/null && _brew_autoupdate
+
 ## mise — gerenciador de versões (substitui asdf/nvm/pyenv)
 command -v mise >/dev/null && eval "$(mise activate zsh)"
 


### PR DESCRIPTION
## O quê
Atualiza o Homebrew automaticamente na abertura do terminal, **no máximo 1x a cada 24h**, sem travar o prompt.

## Como funciona
Função `_brew_autoupdate` na `dotfiles/.zshrc`:
- Usa um **stamp file** (`~/.cache/brew-autoupdate.stamp`) e só dispara se passou ≥ 24h.
- Roda `brew update && brew upgrade --formula && brew cleanup` **destacado** (`&!`) — o prompt aparece na hora; segue mesmo se a aba for fechada.
- Saída vai pra `~/.cache/brew-autoupdate.log`.

## Decisões
- **Stamp marcado no início**: abrir várias abas de manhã dispara só um `brew` (as outras veem o stamp fresco). Trade-off: se falhar, só re-tenta no dia seguinte (erro fica no log).
- **`--formula` apenas**: cask em Mac gerenciado pede `sudo` interativo, que travaria em background esperando senha. Casks continuam manuais (`brew upgrade --cask`).

## Teste
- `zsh -n dotfiles/.zshrc` passou.
- `.zshrc` é symlinkada, então já vale no próximo `exec zsh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)