### PR TITLE
docs(readme): documenta fix do CA do Zscaler pro podman e passo podman-machine

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -71,8 +71,29 @@ Each folder has its own `README.md`. Root files worth knowing:
 - `just link` — symlink the shared configs (zsh, starship, nvim, mise…); existing real files are backed up first
 - `just mise-install` — install the toolchains from [`mise/config.toml`](./mise/config.toml)
 - `just seed` — copy secret/identity templates (`.gitconfig`, `.wakatime.cfg`, `~/.zshrc.local`) **only if missing**
+- `just podman-machine` — create/start the podman Linux VM (on macOS containers run inside it)
 
 Then fill in your identity/keys: git name/email, WakaTime key, and the secrets in `~/.zshrc.local`.
+
+### Podman behind a corporate proxy (Zscaler)
+
+On a managed machine with **Zscaler** (TLS inspection), `podman pull` fails with
+`x509: certificate signed by unknown authority` — the VM doesn't trust the Zscaler CA.
+The fix is to inject the root CA (already in the macOS keychain) into the VM trust store:
+
+```sh
+# export the Zscaler root CA from the System keychain
+security find-certificate -a -c "Zscaler Root CA" -p /Library/Keychains/System.keychain > /tmp/zscaler-root-ca.crt
+
+# copy it into the VM and refresh the trust store
+podman machine ssh 'cat > /tmp/zscaler-root-ca.crt' < /tmp/zscaler-root-ca.crt
+podman machine ssh 'sudo cp /tmp/zscaler-root-ca.crt /etc/pki/ca-trust/source/anchors/ && sudo update-ca-trust'
+```
+
+> ⚠️ This is **ephemeral**: if the VM is recreated (`podman machine rm` + `init`), repeat the step.
+
+To use tools that talk to the default Docker socket (testcontainers, etc.),
+install the helper once: `sudo $(brew --prefix)/bin/podman-mac-helper install && podman machine stop && podman machine start`.
 
 ### Maintenance
 

--- a/README.md
+++ b/README.md
@@ -71,8 +71,29 @@ O `just bootstrap` é **idempotente** e executa:
 - `just link` — cria os symlinks dos configs compartilhados (zsh, starship, nvim, mise…); arquivos reais existentes têm backup feito antes
 - `just mise-install` — instala os toolchains do [`mise/config.toml`](./mise/config.toml)
 - `just seed` — copia os templates de segredo/identidade (`.gitconfig`, `.wakatime.cfg`, `~/.zshrc.local`) **só se não existirem**
+- `just podman-machine` — cria/inicia a VM Linux do podman (no macOS containers rodam dentro dela)
 
 Depois, preencha sua identidade/chaves: nome/e-mail do git, chave do WakaTime e os segredos em `~/.zshrc.local`.
+
+### Podman atrás de proxy corporativo (Zscaler)
+
+Em máquina gerenciada com **Zscaler** (inspeção de TLS), o `podman pull` falha com
+`x509: certificate signed by unknown authority` — a VM não confia no CA do Zscaler.
+O fix é injetar o root CA (que já está no keychain do macOS) na trust store da VM:
+
+```sh
+# exporta o root CA do Zscaler do System keychain
+security find-certificate -a -c "Zscaler Root CA" -p /Library/Keychains/System.keychain > /tmp/zscaler-root-ca.crt
+
+# copia para dentro da VM e atualiza a trust store
+podman machine ssh 'cat > /tmp/zscaler-root-ca.crt' < /tmp/zscaler-root-ca.crt
+podman machine ssh 'sudo cp /tmp/zscaler-root-ca.crt /etc/pki/ca-trust/source/anchors/ && sudo update-ca-trust'
+```
+
+> ⚠️ É **efêmero**: se a VM for recriada (`podman machine rm` + `init`), repita o passo.
+
+Para usar ferramentas que falam com o socket padrão do Docker (testcontainers, etc.),
+instale o helper uma vez: `sudo $(brew --prefix)/bin/podman-mac-helper install && podman machine stop && podman machine start`.
 
 ### Manutenção
 


### PR DESCRIPTION
Em máquina gerenciada com Zscaler o `podman pull` falha por TLS; documenta
como injetar o root CA na VM. Inclui também o passo `podman-machine` na lista
do bootstrap e a dica do podman-mac-helper. PT-BR e EN.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
