### PR TITLE
docs(nvim): usa placeholder no exemplo de symlink do mise

### DIFF
--- a/nvim/SETUP.md
+++ b/nvim/SETUP.md
@@ -122,7 +122,7 @@ obrigatórios vêm do próprio spec.
 Existe um symlink em:
 
 ```
-~/.local/state/mise/trusted-configs/Users-U004334-4bb99e5cee51aebc  →  /Users/U004334
+~/.local/state/mise/trusted-configs/Users-<você>-<hash>  →  /Users/<você>
 ```
 
 Durante a sessão isso foi inicialmente sinalizado como "loop recursivo a corrigir",


### PR DESCRIPTION
## O quê

Remove dado específico da minha máquina do `nvim/SETUP.md`: o exemplo do symlink do trust-store do mise mostrava o usuário real (`U004334`) e um hash de máquina. Trocado por `<você>`/`<hash>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)