### PR TITLE
feat(claude): acompanha consumo de tokens (statusline + status do mês no WezTerm)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@ do meu ambiente; o setup é feito com [`just`](./justfile) (sem provisionador pe
 - `dotfiles/` — dotfiles da home (templates, **sem segredos**)
 - `nvim/` — Neovim como IDE (Go/.NET/Kotlin); detalhes em `nvim/SETUP.md`
 - `wezterm/`, `starship/`, `mise/` — terminal, prompt e toolchains
+- `claude/` — config do Claude Code + acompanhamento de consumo de tokens (statusline + status do mês no WezTerm); detalhes em `claude/README.md`
 - `Brewfile` — pacotes Homebrew · `justfile` — bootstrap/manutenção
 - `.github/workflows/ci.yml` — CI (lint + gitleaks)
 

--- a/claude/README.md
+++ b/claude/README.md
@@ -1,0 +1,42 @@
+# claude
+
+Configuração do [Claude Code](https://claude.com/claude-code) e acompanhamento de
+consumo de tokens.
+
+## Arquivos
+
+| Arquivo | O que é |
+|---|---|
+| `settings.json` | **Modelo** das settings do Claude Code (sem nada da empresa). Seedado para `~/.claude/settings.json` pelo `just seed` — só se não existir. |
+| `statusline.sh` | Statusline **dentro** do Claude Code: `modelo · $custo-sessão · branch✓/✗ · %contexto · %5h · %7d · $mês/$limite`. O gasto do mês reaproveita o `usage.sh` (mesma fonte/cores do WezTerm). Ligado pela chave `statusLine` do `settings.json`. |
+| `usage.sh` | Consumo do **mês** vs o limite mensal + gasto de hoje + projeção do fechamento (`$59/$300 · 20% · hoje $9 · proj $295`). Usado pelo statusline e pelo `right_status` do WezTerm. |
+| `usage-budget.example` | Modelo do limite mensal. Seedado para `~/.claude/usage-budget` (local, **fora do git**, como o `~/.zshrc.local`). |
+
+## De onde vêm os números
+
+- **`statusline.sh`** lê o JSON que o próprio Claude Code injeta na sessão
+  (custo da sessão, % de contexto, % dos limites de 5h/7d — estes só em Pro/Max).
+- **`usage.sh`** usa o [`ccusage`](https://github.com/ryoppippi/ccusage) (instalado
+  via `mise`: `npm:ccusage` no [`../mise/config.toml`](../mise/config.toml)), que
+  soma os logs locais em `~/.claude` e bate com a UI do Claude.
+
+Os dois são **estimativa local**. O saldo/percentual real da conta (ex.: "US$300,
+21% usado") é server-side e só aparece no menu da conta — não é exposto por API.
+Por isso o limite mensal é configurado à mão em `~/.claude/usage-budget`.
+
+No **WezTerm** o consumo do Claude aparece à direita; à esquerda ficam os recursos
+da máquina (`CPU x% · MEM y%`), de [`../wezterm/sysinfo.sh`](../wezterm/sysinfo.sh).
+
+## Setup numa máquina nova
+
+`just seed` cria `~/.claude/settings.json` e `~/.claude/usage-budget`. Depois:
+
+1. Ajuste o limite mensal (US$) em `~/.claude/usage-budget` — varia por máquina
+   (trabalho: o limite que te deram; pessoal/Pro: `0` para mostrar só o gasto).
+2. `mise install` garante o `ccusage` (já entra no `just bootstrap`).
+3. O statusline aparece em novas sessões do Claude Code; o status do mês aparece
+   no WezTerm (recarrega o config sozinho).
+
+> O `settings.json` é **seedado** (cópia, não symlink) de propósito: ele acumula
+> estado por máquina (plugins, prefs), então cada máquina tem o seu. O plugin
+> `ruflo` não entra no modelo — é instalado por máquina com `just ruflo`.

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -1,0 +1,10 @@
+{
+  "effortLevel": "high",
+  "tui": "fullscreen",
+  "theme": "dark",
+  "statusLine": {
+    "type": "command",
+    "command": "$HOME/dev/marcopollivier/big-bang/claude/statusline.sh",
+    "padding": 0
+  }
+}

--- a/claude/statusline.sh
+++ b/claude/statusline.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# Statusline do Claude Code — tema Tokyo Night (alinhado com starship/wezterm).
+#
+# O Claude Code chama este script a cada atualização, mandando um JSON pela
+# stdin com infos da sessão (modelo, custo, contexto, rate limits...). A gente
+# lê esse JSON, monta uma linha colorida e imprime no stdout — o que sair daqui
+# vira a barra de status no rodapé da sessão.
+#
+# Mostra: modelo · custo da sessão (US$) · % da janela de contexto ·
+#         % do limite de 5h e de 7 dias (só aparecem em plano Pro/Max) ·
+#         gasto do mês vs limite mensal (mesma fonte/cores do status do WezTerm).
+# ---------------------------------------------------------------------------
+
+input=$(cat)
+
+# Paleta Tokyo Night (truecolor — o WezTerm suporta).
+c_green=$'\033[38;2;158;206;106m'
+c_yellow=$'\033[38;2;224;175;104m'
+c_orange=$'\033[38;2;255;158;100m'
+c_red=$'\033[38;2;247;118;142m'
+c_purple=$'\033[38;2;187;154;247m'
+c_dim=$'\033[38;2;86;95;137m'
+reset=$'\033[0m'
+
+# Sem jq não dá pra parsear o JSON com segurança — degrada com elegância.
+if ! command -v jq >/dev/null 2>&1; then
+  printf 'Claude (instale jq para o statusline completo)'
+  exit 0
+fi
+
+# Extrai todos os campos de uma vez (separados por TAB). Campos ausentes viram "".
+IFS=$'\t' read -r model cost ctx h5 d7 cwd <<EOF
+$(printf '%s' "$input" | jq -r '
+  [ .model.display_name // "Claude",
+    (.cost.total_cost_usd // 0),
+    (.context_window.used_percentage // ""),
+    (.rate_limits.five_hour.used_percentage // ""),
+    (.rate_limits.seven_day.used_percentage // ""),
+    (.workspace.current_dir // .cwd // "")
+  ] | @tsv')
+EOF
+
+# Cor conforme o nível de uso de um percentual (recebe algo como "73.4").
+pct_color() {
+  local p=${1%.*} # só a parte inteira
+  if [ -z "$p" ]; then printf '%s' "$c_dim"; return; fi
+  if   [ "$p" -ge 80 ]; then printf '%s' "$c_red"
+  elif [ "$p" -ge 50 ]; then printf '%s' "$c_yellow"
+  else                       printf '%s' "$c_green"
+  fi
+}
+
+# Cor do gasto do mês (mesmas faixas do WezTerm): <60 verde · 60 amarelo ·
+# 70 laranja · 85 vermelho. Sem % (sem limite configurado) = verde.
+budget_color() {
+  local p=$1
+  if [ -z "$p" ]; then printf '%s' "$c_green"; return; fi
+  if   [ "$p" -ge 85 ]; then printf '%s' "$c_red"
+  elif [ "$p" -ge 70 ]; then printf '%s' "$c_orange"
+  elif [ "$p" -ge 60 ]; then printf '%s' "$c_yellow"
+  else                       printf '%s' "$c_green"
+  fi
+}
+
+# Segmento de percentual: "<icone> <NN>% <label>" (ou nada, se vazio).
+seg_pct() {
+  local val=$1 icon=$2 label=$3
+  [ -z "$val" ] && return
+  local int=${val%.*}
+  printf '  %s%s %s%%%s%s %s%s' \
+    "$(pct_color "$val")" "$icon" "$int" "$reset" "$c_dim" "$label" "$reset"
+}
+
+out="${c_purple}󰚩 ${model}${reset}"
+out+="  ${c_green}$(printf '$%.2f' "$cost")${reset}"
+
+# Branch git do diretório da sessão (✓ limpo / ✗ com mudanças não commitadas).
+if [ -n "$cwd" ] && command -v git >/dev/null 2>&1; then
+  branch=$(git -C "$cwd" branch --show-current 2>/dev/null)
+  if [ -n "$branch" ]; then
+    if [ -n "$(git -C "$cwd" status --porcelain 2>/dev/null)" ]; then
+      out+="  ${c_yellow} ${branch} ✗${reset}"
+    else
+      out+="  ${c_dim} ${branch} ✓${reset}"
+    fi
+  fi
+fi
+
+out+="$(seg_pct "$ctx" "󰍛" "ctx")"
+out+="$(seg_pct "$h5"  "" "5h")"
+out+="$(seg_pct "$d7"  "" "7d")"
+
+# Gasto do mês vs limite — reaproveita o usage.sh (mesma fonte/cache do WezTerm).
+script_dir=$(cd "$(dirname "$0")" 2>/dev/null && pwd)
+if [ -n "$script_dir" ] && [ -x "$script_dir/usage.sh" ]; then
+  month=$("$script_dir/usage.sh" 2>/dev/null)
+  if [ -n "$month" ] && [ "$month" != "…" ]; then
+    mpct=$(printf '%s' "$month" | grep -oE '[0-9]+%' | head -1 | tr -d '%')
+    out+="  $(budget_color "$mpct") ${month}${reset}"
+  fi
+fi
+
+printf '%s' "$out"

--- a/claude/usage-budget.example
+++ b/claude/usage-budget.example
@@ -1,0 +1,9 @@
+# Limite mensal de tokens do Claude Code, em US$ (reseta na virada do mês).
+# É pessoal e varia por máquina — por isso fica AQUI (local), fora do git,
+# no mesmo espírito do ~/.zshrc.local.
+#
+# O `just seed` copia este modelo para ~/.claude/usage-budget (só se não existir).
+# Deixe apenas o número na última linha:
+#   - Máquina de trabalho: o limite que te deram (ex.: 300)
+#   - Máquina pessoal (Pro): use 0 (ou apague o número) p/ mostrar só o gasto, sem %
+300

--- a/claude/usage.sh
+++ b/claude/usage.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# Consumo do MÊS atual no Claude Code vs o seu limite mensal de tokens.
+#
+# Saída (para o status do WezTerm e do Claude Code):
+#   com limite configurado:  "$59/$300 · 20% · hoje $9 · proj $295"
+#   sem limite:              "$59 mês · hoje $9 · proj $295"
+# (proj = projeção do fechamento do mês pelo ritmo atual)
+#
+# O gasto vem do ccusage (mise: npm:ccusage), que soma os logs locais ~/.claude
+# e bate com a UI do Claude — é ESTIMATIVA local. O limite mensal (ex.: US$300 na
+# máquina de trabalho) é pessoal e varia por máquina, então fica num arquivo
+# LOCAL e NÃO-versionado: ~/.claude/usage-budget (modelo: usage-budget.example).
+#
+# Cache (TTL 120s) + refresh em background: cada tick do WezTerm só lê um arquivo.
+# ---------------------------------------------------------------------------
+
+ccusage_bin="$HOME/.local/share/mise/shims/ccusage"
+cache="${TMPDIR:-/tmp}/claude-usage"
+budget_file="$HOME/.claude/usage-budget"
+ttl=120
+
+# Primeiro número no arquivo de limite (ignora linhas de comentário com #).
+read_budget() {
+  [ -f "$budget_file" ] || return
+  grep -vE '^[[:space:]]*#' "$budget_file" 2>/dev/null \
+    | grep -oE '[0-9]+(\.[0-9]+)?' | head -1
+}
+
+refresh() {
+  local month spend today budget proj dom dim out
+  month=$(date +%Y-%m)
+  # Gasto do mês.
+  spend=$("$ccusage_bin" monthly --json 2>/dev/null \
+    | jq -r --arg m "$month" '(.monthly[] | select(.period == $m) | .totalCost) // 0' 2>/dev/null)
+  [ -z "$spend" ] && spend=0
+  # Gasto de hoje.
+  today=$("$ccusage_bin" daily --json --since "$(date +%Y%m%d)" 2>/dev/null \
+    | jq -r '[.daily[].modelBreakdowns[].cost] | add // 0' 2>/dev/null)
+  [ -z "$today" ] && today=0
+  # Projeção do fechamento do mês: gasto/dia-atual * dias-do-mês.
+  dom=$(date +%-d)              # dia do mês (1..31)
+  dim=$(date -v1d -v+1m -v-1d +%-d) # dias no mês atual
+  proj=$(awk -v s="$spend" -v d="$dom" -v t="$dim" 'BEGIN { printf "%.0f", (d > 0 ? s / d * t : s) }')
+
+  budget=$(read_budget)
+  if [ -n "$budget" ] && [ "$budget" != "0" ]; then
+    out=$(awk -v s="$spend" -v b="$budget" -v h="$today" -v p="$proj" \
+      'BEGIN { printf "$%.0f/$%.0f · %.0f%% · hoje $%.0f · proj $%d", s, b, (s / b) * 100, h, p }')
+  else
+    out=$(awk -v s="$spend" -v h="$today" -v p="$proj" \
+      'BEGIN { printf "$%.2f mês · hoje $%.2f · proj $%d", s, h, p }')
+  fi
+  printf '%s' "$out" >"$cache.tmp" 2>/dev/null && mv "$cache.tmp" "$cache"
+}
+
+# Idade do cache em segundos (valor enorme se o arquivo não existir).
+age=999999
+[ -f "$cache" ] && age=$(( $(date +%s) - $(stat -f %m "$cache") ))
+
+# Cache velho/inexistente → dispara refresh desacoplado (não bloqueia o WezTerm).
+if [ "$age" -gt "$ttl" ]; then
+  refresh >/dev/null 2>&1 &
+fi
+
+# Imprime o valor atual (o anterior enquanto o refresh roda; "…" na 1ª vez).
+cat "$cache" 2>/dev/null || printf '…'

--- a/justfile
+++ b/justfile
@@ -55,7 +55,10 @@ seed:
     just _seed "{{ repo }}/dotfiles/.wakatime.cfg"        "{{ home }}/.wakatime.cfg"
     just _seed "{{ repo }}/dotfiles/.aws/config"          "{{ home }}/.aws/config"
     just _seed "{{ repo }}/dotfiles/.clojure/deps.edn"    "{{ home }}/.clojure/deps.edn"
+    just _seed "{{ repo }}/claude/settings.json"          "{{ home }}/.claude/settings.json"
+    just _seed "{{ repo }}/claude/usage-budget.example"   "{{ home }}/.claude/usage-budget"
     @echo "→ Now fill identity/keys in ~/.gitconfig, ~/.wakatime.cfg and ~/.zshrc.local"
+    @echo "→ Set your monthly token limit (US\$) in ~/.claude/usage-budget"
 
 # Update the Brewfile from what's currently installed
 brew-dump:

--- a/mise/config.toml
+++ b/mise/config.toml
@@ -11,3 +11,7 @@ java = "temurin-21"
 kotlin = { version = "latest", asset_pattern = "kotlin-compiler-*.zip", bin_path = "kotlinc/bin" }
 node = "lts"
 dotnet = "latest"
+
+# CLI que estima o gasto do Claude Code a partir dos logs locais (~/.claude).
+# Alimenta o status do WezTerm (wezterm/.wezterm.lua) e o relatório `ccusage daily`.
+"npm:ccusage" = "latest"

--- a/wezterm/.wezterm.lua
+++ b/wezterm/.wezterm.lua
@@ -97,4 +97,67 @@ config.keys = {
   { key = "0", mods = "CMD", action = act.ResetFontSize },
 }
 
+-- ===========================================================================
+-- Status bars: máquina (esquerda) · consumo do Claude Code (direita)
+-- ===========================================================================
+-- Esquerda  → wezterm/sysinfo.sh: "CPU 6% · MEM 7%" (recursos da máquina).
+-- Direita   → claude/usage.sh: "$61/$300 · 20% · hoje $9 · proj $295" (gasto do
+--             mês vs limite + hoje + projeção; estimativa local via ccusage, bate
+--             com a UI do Claude; limite em ~/.claude/usage-budget).
+-- Ambos os scripts têm cache próprio, então cada tick aqui é barato.
+local repo = wezterm.home_dir .. "/dev/marcopollivier/big-bang"
+local usage_script = repo .. "/claude/usage.sh"
+local sysinfo_script = repo .. "/wezterm/sysinfo.sh"
+
+-- Cor por nível de uso (verde → amarelo → laranja → vermelho).
+local function level_color(pct, yellow, orange, red)
+  if pct then
+    if pct >= red then
+      return "#f7768e"
+    elseif pct >= orange then
+      return "#ff9e64"
+    elseif pct >= yellow then
+      return "#e0af68"
+    end
+  end
+  return "#9ece6a"
+end
+
+wezterm.on("update-status", function(window, _pane)
+  -- Direita: consumo do Claude Code. Cor pela % do limite (60/70/85).
+  local ok, usage = wezterm.run_child_process({ usage_script })
+  usage = (ok and usage or ""):gsub("%s+$", "")
+  if usage == "" or usage == "…" then
+    window:set_right_status("")
+  else
+    local pct = tonumber(usage:match("(%d+)%%"))
+    window:set_right_status(wezterm.format({
+      { Foreground = { Color = level_color(pct, 60, 70, 85) } },
+      { Text = "󰚩 " .. usage .. "  " },
+    }))
+  end
+
+  -- Esquerda: recursos da máquina. Cor pelo maior entre CPU/MEM (70/85/95).
+  local ok2, sys = wezterm.run_child_process({ sysinfo_script })
+  sys = (ok2 and sys or ""):gsub("%s+$", "")
+  if sys == "" or sys == "…" then
+    window:set_left_status("")
+  else
+    local hi = 0
+    for n in sys:gmatch("(%d+)%%") do
+      local v = tonumber(n)
+      if v and v > hi then
+        hi = v
+      end
+    end
+    window:set_left_status(wezterm.format({
+      { Foreground = { Color = level_color(hi, 70, 85, 95) } },
+      { Text = "  " .. sys .. " " },
+    }))
+  end
+end)
+
+-- A cada quantos ms o WezTerm reavalia os status (os scripts têm cache próprio).
+config.status_update_interval = 10000
+
 return config

--- a/wezterm/sysinfo.sh
+++ b/wezterm/sysinfo.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# Recursos da máquina (CPU total e memória) para o left_status do WezTerm.
+# Saída: "CPU 6% · MEM 7%"
+#
+#   - CPU: soma do %cpu de todos os processos / nº de núcleos (uso total, não
+#     por core), via `ps` — rápido e sem o atraso de 1s do `top -l 2`.
+#   - MEM: pressão de memória (100 - "free percentage" do `memory_pressure`).
+#     No macOS a RAM aparece quase sempre "cheia" por causa de cache; este número
+#     reflete a PRESSÃO real (baixo = folgado), mais honesto que o Monitor de
+#     Atividade.
+#
+# Cache curto (TTL 4s) + refresh em background, pra não travar a barra.
+# ---------------------------------------------------------------------------
+
+cache="${TMPDIR:-/tmp}/wezterm-sysinfo"
+ttl=4
+
+refresh() {
+  local ncpu cpu mem
+  ncpu=$(sysctl -n hw.ncpu 2>/dev/null); [ -z "$ncpu" ] && ncpu=1
+  cpu=$(ps -A -o %cpu 2>/dev/null \
+    | awk -v n="$ncpu" 'NR > 1 { s += $1 } END { printf "%.0f", (n > 0 ? s / n : s) }')
+  mem=$(memory_pressure 2>/dev/null \
+    | awk -F: '/free percentage/ { v = $2; gsub(/[^0-9.]/, "", v); printf "%.0f", 100 - v }')
+  [ -z "$cpu" ] && cpu=0
+  [ -z "$mem" ] && mem=0
+  printf 'CPU %s%% · MEM %s%%' "$cpu" "$mem" >"$cache.tmp" 2>/dev/null && mv "$cache.tmp" "$cache"
+}
+
+age=999999
+[ -f "$cache" ] && age=$(( $(date +%s) - $(stat -f %m "$cache") ))
+if [ "$age" -gt "$ttl" ]; then
+  refresh >/dev/null 2>&1 &
+fi
+
+cat "$cache" 2>/dev/null || printf '…'


### PR DESCRIPTION
- claude/statusline.sh: custo/contexto/limites na sessão do Claude Code
- claude/usage.sh + ccusage (mise npm:ccusage): gasto do mês vs limite no WezTerm
- claude/settings.json e usage-budget.example: seedados via `just seed`
- limite mensal por máquina fica em ~/.claude/usage-budget (local, fora do git)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
