### PR TITLE
feat(dotfiles): template de .npmrc (seed, sem segredos)

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Tudo que carrega identidade ou credenciais é tratado de outro jeito:
 | Tipo de arquivo | Estratégia | Versionado? | Exemplos |
 |---|---|---|---|
 | Config compartilhado, **sem segredo** | **symlink** (`just link`) | ✅ sim | `.zshrc`, `starship.toml`, `nvim/`, `mise/config.toml` |
-| Com identidade / segredo | **seed** — copiado **só se faltar** (`just seed`), nunca sobrescreve | ❌ não | `.gitconfig`, `.wakatime.cfg` |
+| Com identidade / segredo | **seed** — copiado **só se faltar** (`just seed`), nunca sobrescreve | ❌ não | `.gitconfig`, `.wakatime.cfg`, `.npmrc` |
 | Puramente segredos / específico da máquina | mantido num arquivo **git-ignored** que você preenche à mão | ❌ não | `~/.zshrc.local` |
 
 Então a proteção em camadas é:

--- a/dotfiles/.npmrc
+++ b/dotfiles/.npmrc
@@ -1,0 +1,17 @@
+# ~/.npmrc — config do npm da máquina. Template SEM segredos.
+# Copiado para ~/.npmrc via `just seed` (só se não existir; nunca sobrescreve).
+#
+# O token NÃO vive aqui: o npm expande ${NPM_TOKEN} a partir do ambiente.
+# Defina-o em ~/.zshrc.local (gitignored). Ex.:
+#   export NPM_TOKEN="..."
+
+# Registry padrão (descomente/ajuste se usar um registry privado/proxy)
+# registry=https://registry.npmjs.org/
+
+# Auth por token (lido de ${NPM_TOKEN} no ambiente; não comita segredo)
+# //registry.npmjs.org/:_authToken=${NPM_TOKEN}
+
+# Padrões úteis
+# save-exact=true
+# fund=false
+# audit=false

--- a/dotfiles/.zshrc.local.example
+++ b/dotfiles/.zshrc.local.example
@@ -10,6 +10,9 @@
 ## GitHub
 # export GITHUB_TOKEN=""
 
+## npm (token lido por ~/.npmrc via ${NPM_TOKEN})
+# export NPM_TOKEN=""
+
 ## Contextos EKS usados por k8s-p / k8s-h (ARNs da sua infra)
 # export EKS_PRD_ARN="arn:aws:eks:<region>:<account-id>:cluster/<cluster-prd>"
 # export EKS_HML_ARN="arn:aws:eks:<region>:<account-id>:cluster/<cluster-hml>"

--- a/justfile
+++ b/justfile
@@ -54,6 +54,7 @@ seed:
     just _seed "{{ repo }}/dotfiles/.gitconfig"           "{{ home }}/.gitconfig"
     just _seed "{{ repo }}/dotfiles/.wakatime.cfg"        "{{ home }}/.wakatime.cfg"
     just _seed "{{ repo }}/dotfiles/.aws/config"          "{{ home }}/.aws/config"
+    just _seed "{{ repo }}/dotfiles/.npmrc"               "{{ home }}/.npmrc"
     just _seed "{{ repo }}/dotfiles/.clojure/deps.edn"    "{{ home }}/.clojure/deps.edn"
     @echo "→ Now fill identity/keys in ~/.gitconfig, ~/.wakatime.cfg and ~/.zshrc.local"
 


### PR DESCRIPTION
## O que

Adiciona um template de `.npmrc` ao fluxo de dotfiles, seguindo a convenção de **seed** (identidade/segredo): copiado para `~/.npmrc` via `just seed` **só se não existir** — nunca sobrescreve um arquivo real.

## Por que

O repo ainda não cobria config de npm. Útil para configurar registry privado / auth de forma consistente em máquina nova.

## Decisões

- **Secret-free no git**: o token não vive no arquivo. O npm expande `${NPM_TOKEN}` a partir do ambiente, definido em `~/.zshrc.local` (gitignored). Passa no gitleaks do CI.
- **Seed, não symlink**: como guarda identidade/registry, é copiado uma vez e nunca linkado de volta ao repo (mesma estratégia de `.gitconfig` / `.wakatime.cfg`).

## Mudanças

- `dotfiles/.npmrc` — template comentado (registry / `_authToken=${NPM_TOKEN}` / flags)
- `justfile` — nova linha de seed `~/.npmrc`
- `dotfiles/.zshrc.local.example` — placeholder `NPM_TOKEN`
- `README.md` — `.npmrc` na tabela de templates de seed

## Como aplicar (depois do merge)

`just seed` cria `~/.npmrc` se faltar → descomentar registry/`_authToken` → exportar `NPM_TOKEN` em `~/.zshrc.local`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)