### PR TITLE
feat(cmux): config inicial espelhando usabilidade do WezTerm

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@ do meu ambiente; o setup é feito com [`just`](./justfile) (sem provisionador pe
 - `dotfiles/` — dotfiles da home (templates, **sem segredos**)
 - `nvim/` — Neovim como IDE (Go/.NET/Kotlin); detalhes em `nvim/SETUP.md`
 - `wezterm/`, `starship/`, `mise/` — terminal, prompt e toolchains
+- `cmux/` — orquestrador de agentes de IA (terminal via Ghostty embutido); em teste como alternativa ao WezTerm. Detalhes em `cmux/README.md`
 - `claude/` — config do Claude Code + acompanhamento de consumo de tokens (statusline + status do mês no WezTerm); detalhes em `claude/README.md`
 - `Brewfile` — pacotes Homebrew · `justfile` — bootstrap/manutenção
 - `.github/workflows/ci.yml` — CI (lint + gitleaks)

--- a/cmux/README.md
+++ b/cmux/README.md
@@ -1,0 +1,66 @@
+# cmux
+
+[cmux](https://cmux.com) (`com.cmuxterm.app`) instalado em `/Applications/cmux.app`.
+Em teste como alternativa ao WezTerm.
+
+> **Importante — o que o cmux *é*:** ele **não é um terminal genérico** como o
+> WezTerm. É um **orquestrador de agentes de IA de código**: roda vários agentes
+> (Claude Code, Codex, Gemini, opencode…) **em paralelo**, cada um num workspace
+> isolado (git worktree / VM), com sidebar de workspaces, diff viewer, browser
+> embutido e integração com PRs. O terminal é renderizado com o **Ghostty**
+> embutido — então dá pra usar como terminal com splits/abas, mas esse é só um
+> pedaço do que ele faz. Veja ["Potencial"](#potencial).
+
+## Como a config funciona (duas camadas)
+
+| Camada | Arquivo (symlink via `just link`) | Controla |
+|---|---|---|
+| **Ghostty** | `cmux/ghostty.config` → `~/.config/ghostty/config` | Aparência/comportamento **do terminal**: fonte, tema, transparência, blur, cursor, copy-on-select, scrollback, atalhos do terminal (limpar, fonte) |
+| **cmux** | `cmux/cmux.json` → `~/.config/cmux/cmux.json` | Atalhos de **janela/split/foco**, abas, comportamento do app |
+
+Recarregar as duas sem reiniciar o app: `cmux reload-config` (ou **CMD+Shift+,**).
+Validar: `cmux config validate`. O `just link` faz backup do `cmux.json` real em `.bak`.
+
+## Atalhos (espelhando o WezTerm)
+
+| Ação | WezTerm | cmux (após este config) |
+|---|---|---|
+| Split embaixo | `CMD+Enter` | `CMD+Enter` |
+| Split à direita | `CMD+Shift+Enter` | `CMD+Shift+Enter` |
+| Split à esquerda | `CMD+Alt+Enter` | — (cmux só divide direita/baixo) |
+| Mover foco entre panes | `CMD+setas` | `CMD+setas` |
+| Zoom no pane | `CMD+Shift+Z` | `CMD+Shift+Z` |
+| Modo de cópia | `CMD+Shift+X` | `CMD+Shift+X` |
+| Fechar pane/aba | `CMD+W` | `CMD+W` |
+| Paleta de comandos | `CMD+Shift+P` | `CMD+Shift+P` |
+| Limpar terminal | `CMD+K` | `CMD+K` (via Ghostty) |
+| Fonte +/-/0 | `CMD +/-/0` | `CMD +/-/0` (via Ghostty) |
+| Nova aba / surface | — | `CMD+N` / `CMD+T` |
+| Equalizar splits | `CMD+Ctrl+setas` (resize) | `CMD+Ctrl+=` (resize por arrasto) |
+
+### Diferenças que ficam (não têm equivalente 1:1)
+- **Sem "split à esquerda".** O canvas do cmux só divide para a direita/baixo.
+- **Resize de pane por teclado** (o `CMD+Ctrl+setas` do wezterm) não existe — no
+  cmux se redimensiona arrastando a borda, ou `CMD+Ctrl+=` para equalizar.
+- Dim de panes inativos: o wezterm escurece; aqui não há equivalente direto.
+
+## Potencial
+
+O ganho real do cmux **não** é ser um terminal melhor — é o que vem por cima dele:
+
+1. **Paralelismo de agentes.** Disparar N agentes (Claude Code etc.) em workspaces
+   isolados ao mesmo tempo e revisar os diffs lado a lado — sem misturar contexto
+   nem pisar no mesmo working tree. Forte pra "tenta 3 abordagens e eu escolho".
+2. **Isolamento por workspace.** Cada agente roda em seu git worktree / VM, com
+   branch e diretório próprios — combina com a regra "uma branch por escopo".
+3. **Diff viewer + PR integrados.** Revisar mudanças (`cmux diff`), abrir/clicar PRs
+   pela sidebar, ver status de git/portas por workspace.
+4. **Browser embutido + canvas.** Terminal, browser e markdown como "surfaces" no
+   mesmo canvas — útil pra acompanhar app rodando ao lado do agente.
+5. **Controle via socket/CLI.** `cmux <path>`, `cmux open`, `cmux diff`, `cmux rpc`,
+   hooks por agente — dá pra automatizar/scriptar o fluxo (inclusive a partir daqui).
+6. **Hooks de notificação.** Avisa quando um agente termina/precisa de input — bom
+   pra tocar vários em paralelo sem ficar olhando.
+
+Comandos úteis pra explorar: `cmux docs agents`, `cmux docs settings`,
+`cmux docs shortcuts`, `cmux capabilities`, `cmux welcome`.

--- a/cmux/cmux.json
+++ b/cmux/cmux.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://raw.githubusercontent.com/manaflow-ai/cmux/main/web/data/cmux.schema.json",
+  "schemaVersion": 1,
+
+  // Config do cmux gerenciada por este repo (symlinkado por `just link`).
+  // JSONC (JSON com comentários). Só listamos as chaves que QUEREMOS sobrescrever;
+  // o que não está aqui cai no default salvo nas Settings do app.
+  // Recarrega com:  cmux reload-config   (ou CMD+Shift+,)
+  //
+  // OBS: a APARÊNCIA do terminal (fonte, tema, transparência, copy-on-select)
+  // fica no Ghostty -> cmux/ghostty.config. Aqui ficam só os atalhos de janela/split.
+
+  "terminal": {
+    // Selecionar com o mouse já copia (espelha o copy-on-select do Ghostty).
+    "copyOnSelect": true
+  },
+
+  // Atalhos remapeados pra bater com a memória muscular do WezTerm.
+  // (Defaults do cmux ao lado pra referência.)
+  "shortcuts": {
+    "bindings": {
+      // Splits: CMD+Enter = pane novo EMBAIXO · CMD+Shift+Enter = pane novo À DIREITA
+      // (no cmux não existe "split à esquerda"; o canvas só divide p/ direita/baixo).
+      "splitDown": "cmd+\r",         // default: cmd+shift+d
+      "splitRight": "cmd+shift+\r",  // default: cmd+d
+
+      // Foco entre panes com CMD+setas (no wezterm é assim).
+      "focusLeft": "cmd+←",          // default: cmd+opt+←
+      "focusRight": "cmd+→",         // default: cmd+opt+→
+      "focusUp": "cmd+↑",            // default: cmd+opt+↑
+      "focusDown": "cmd+↓",          // default: cmd+opt+↓
+
+      // Zoom no pane focado (CMD+Shift+Z, igual wezterm).
+      "toggleSplitZoom": "cmd+shift+z", // default: cmd+shift+\r
+
+      // Modo de cópia pelo teclado (CMD+Shift+X, igual wezterm).
+      "toggleTerminalCopyMode": "cmd+shift+x" // default: cmd+shift+m
+
+      // Já batem com o wezterm por padrão (deixados no default):
+      //   commandPalette  = cmd+shift+p
+      //   closeTab        = cmd+w      (fecha o pane/surface focado)
+      //   newTab          = cmd+n
+      //   newSurface      = cmd+t
+      //   equalizeSplits  = cmd+ctrl+= (no wezterm o resize é CMD+CTRL+setas; aqui é arrastar)
+    }
+  }
+}

--- a/cmux/ghostty.config
+++ b/cmux/ghostty.config
@@ -1,0 +1,39 @@
+# Ghostty config — usado pelo terminal embutido do cmux.
+# (cmux renderiza o terminal com o Ghostty; este arquivo controla a APARÊNCIA e
+#  comportamento DO TERMINAL. Splits/abas/foco ficam no cmux.json — o cmux dono do "canvas".)
+# Recarrega com:  cmux reload-config   (sem reiniciar o app)
+#
+# Espelha o visual do ~/.wezterm.lua deste repo.
+
+# --- Fonte -------------------------------------------------------------------
+font-family = Hack Nerd Font Mono
+font-size = 15
+
+# --- Aparência ---------------------------------------------------------------
+# WezTerm usa "Tokyo Night". Alternativas: TokyoNight, TokyoNight Night, TokyoNight Moon, TokyoNight Day.
+theme = TokyoNight Storm
+background-opacity = 0.95
+background-blur = 20
+window-padding-x = 8
+window-padding-y = 8
+
+# Cursor: barra piscando (estilo editor).
+cursor-style = bar
+cursor-style-blink = true
+
+# --- Comportamento -----------------------------------------------------------
+# Selecionar com o mouse já copia pro clipboard (estilo iTerm/tmux/wezterm).
+copy-on-select = clipboard
+# Bastante histórico de rolagem (em bytes).
+scrollback-limit = 10000000
+# Esconde o cursor do mouse enquanto digita.
+mouse-hide-while-typing = true
+
+# --- Atalhos do terminal -----------------------------------------------------
+# Limpar o terminal (CMD+K, como no iTerm/wezterm).
+keybind = cmd+k=clear_screen
+# Tamanho da fonte (CMD +/-/0), como no wezterm.
+keybind = cmd+plus=increase_font_size:1
+keybind = cmd+equal=increase_font_size:1
+keybind = cmd+minus=decrease_font_size:1
+keybind = cmd+zero=reset_font_size

--- a/justfile
+++ b/justfile
@@ -47,6 +47,8 @@ link:
     just _link "{{ repo }}/nvim"                        "{{ home }}/.config/nvim"
     just _link "{{ repo }}/mise/config.toml"           "{{ home }}/.config/mise/config.toml"
     just _link "{{ repo }}/wezterm/.wezterm.lua"       "{{ home }}/.config/wezterm/wezterm.lua"
+    just _link "{{ repo }}/cmux/ghostty.config"        "{{ home }}/.config/ghostty/config"
+    just _link "{{ repo }}/cmux/cmux.json"             "{{ home }}/.config/cmux/cmux.json"
 
 # Seed template files that hold identity/secrets — only if missing (never clobbers)
 seed:


### PR DESCRIPTION
cmux (orquestrador de agentes de IA com terminal via Ghostty embutido) em
teste como alternativa ao WezTerm. Adiciona config em duas camadas:

- cmux/ghostty.config: aparência do terminal (fonte Hack Nerd Font Mono,
  tema TokyoNight Storm, opacidade/blur, cursor de barra, copy-on-select,
  atalhos de limpar/fonte).
- cmux/cmux.json: atalhos de split/foco/zoom/copy-mode batendo com a
  memória muscular do WezTerm (config parcial; resto cai no default do app).

Ambos symlinkados via `just link` (faz backup do cmux.json real).
Documentação e mapeamento de atalhos em cmux/README.md.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
