### PR TITLE
feat(zsh): adiciona zsh-autosuggestions

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -6,6 +6,7 @@
 
 # --- Shell / CLI essentials ---
 brew "starship"        # cross-shell prompt
+brew "zsh-autosuggestions"  # sugestão de comando (cinza) a partir do histórico
 brew "fzf"             # fuzzy finder (Ctrl-R, Ctrl-T)
 brew "ripgrep"         # fast grep (used by Neovim/telescope)
 brew "fd"              # fast find (used by Neovim/telescope)

--- a/dotfiles/.zshrc
+++ b/dotfiles/.zshrc
@@ -205,6 +205,10 @@ command -v mise >/dev/null && eval "$(mise activate zsh)"
 ## fzf — busca fuzzy + keybindings (Ctrl-R, Ctrl-T)
 command -v fzf >/dev/null && source <(fzf --zsh)
 
+## zsh-autosuggestions — sugestão (cinza) do próximo comando a partir do histórico; aceita com →
+[ -f /opt/homebrew/share/zsh-autosuggestions/zsh-autosuggestions.zsh ] \
+    && source /opt/homebrew/share/zsh-autosuggestions/zsh-autosuggestions.zsh
+
 ## .local bin
 export PATH="$HOME/.local/bin":$PATH
 


### PR DESCRIPTION
Resolve a #14.

## O que muda
- `Brewfile`: adiciona `brew "zsh-autosuggestions"` (instalação reprodutível, sem `git clone` de plugin do oh-my-zsh).
- `dotfiles/.zshrc`: faz `source` do plugin após o bloco do fzf, seguindo o mesmo padrão `[ -f ... ] && source` / `command -v ... && source` já usado por fzf e mise.

## Comportamento
Sugere (em cinza) o próximo comando a partir do histórico; aceita com →.

## Validação
- `brew install zsh-autosuggestions` ok; arquivo presente em `/opt/homebrew/share/...`.
- `source` carrega limpo num zsh interativo (`ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE` setado).
- `~/.zshrc` já é symlink para `dotfiles/.zshrc`, então reflete na máquina.

🤖 Generated with [Claude Code](https://claude.com/claude-code)