### PR TITLE
fix(bootstrap): máquina nova funcional de ponta a ponta

### DIFF
--- a/.claude/commands/setup-machine.md
+++ b/.claude/commands/setup-machine.md
@@ -10,8 +10,11 @@ Resumo do fluxo (a skill tem o detalhe):
 1. Garanta Homebrew e `just` (`brew install just`); instale o Homebrew se faltar.
 2. `just bootstrap` — instala o `@Brewfile`, symlinka os configs (com backup),
    confia e instala as toolchains do `mise` (`mise trust` + `mise install`) e faz o *seed* dos templates.
-3. Identidade/segredos: git `user.name/email/signingkey`; `~/.zshrc.local`
-   (ver `@dotfiles/.zshrc.local.example`); WakaTime via `:WakaTimeApiKey` no nvim.
+3. Identidade/segredos: git `user.name/email/signingkey`; **chave GPG** (a
+   assinatura de commits vem ligada — crie a chave e preencha `signingkey`, ou
+   desligue com `git config --global commit.gpgsign false`; passos na skill);
+   `~/.zshrc.local` (ver `@dotfiles/.zshrc.local.example`); WakaTime via
+   `:WakaTimeApiKey` no nvim.
 4. `gh auth login` é interativo — peça ao usuário rodar `! gh auth login --git-protocol ssh --web`.
 5. Valide com `just doctor`, abra o `nvim` pra disparar plugins/LSP e confira o starship numa shell nova.
 6. Resuma o que ficou pronto e o que ainda depende do usuário.

--- a/.claude/skills/machine-bootstrap/SKILL.md
+++ b/.claude/skills/machine-bootstrap/SKILL.md
@@ -29,7 +29,15 @@ nova pronta com o mínimo de esforço, sem expor segredos.
    - Se algo falhar, rode as recipes individuais (`just brew`, `just link`, etc.) e investigue.
 
 3. **Identidade e segredos** (peça ao usuário; não preencha sozinho)
-   - Git: `git config --global user.name`, `user.email`, `user.signingkey` (assinatura GPG está ligada no `.gitconfig`).
+   - Git: `git config --global user.name`, `user.email`, `user.signingkey`.
+   - **Chave GPG (obrigatório antes do primeiro commit):** a assinatura vem
+     ligada no `.gitconfig` (`commit.gpgSign = true`), então sem chave todo
+     `git commit` falha. Guie o usuário:
+     1. `gpg --full-generate-key` (interativo — peça pra rodar com `!` se preciso; RSA 4096, e-mail igual ao do git)
+     2. `gpg --list-secret-keys --keyid-format=long` → copiar o ID depois de `sec rsa4096/`
+     3. `git config --global user.signingkey <ID>`
+     4. Cadastrar a chave pública no GitHub: `gpg --armor --export <ID>` → Settings → SSH and GPG keys
+     - Se o usuário **não quiser assinar**: `git config --global commit.gpgsign false` e pronto.
    - `~/.zshrc.local`: `AWS_*`, `GITHUB_TOKEN`, `EKS_PRD_ARN`, `EKS_HML_ARN` — modelo em `dotfiles/.zshrc.local.example`.
    - WakaTime: dentro do `nvim`, `:WakaTimeApiKey` (chave em https://wakatime.com/settings/api-key).
 

--- a/Brewfile
+++ b/Brewfile
@@ -12,6 +12,7 @@ brew "ripgrep"         # fast grep (used by Neovim/telescope)
 brew "fd"              # fast find (used by Neovim/telescope)
 brew "bat"             # cat with syntax highlighting
 brew "eza"             # modern ls
+brew "jq"              # processador de JSON — usado por claude/statusline.sh e claude/usage.sh
 
 # --- Editor & version manager ---
 brew "neovim"          # editor / IDE (see nvim/)
@@ -22,6 +23,10 @@ brew "gh"              # GitHub CLI
 brew "just"            # command runner — this repo's bootstrap (see justfile)
 brew "lazygit"
 brew "lazydocker"
+brew "git-lfs"         # exigido pelo filtro lfs do .gitconfig (required = true)
+brew "gnupg"           # assinatura de commits (.gitconfig: commit.gpgSign = true)
+brew "pinentry-mac"    # prompt de senha do GPG integrado ao macOS/Keychain
+brew "pre-commit"      # hooks de qualidade locais (pre-commit install; ver .pre-commit-config.yaml)
 
 # --- Cloud / infra ---
 brew "awscli"

--- a/README-en.md
+++ b/README-en.md
@@ -121,6 +121,20 @@ just bootstrap
 [Fork it](#fork-it-make-it-yours)): git name/email in `~/.gitconfig`, WakaTime
 key in `~/.wakatime.cfg`, and the secrets in `~/.zshrc.local`.
 
+> 🔑 **GPG key — don't skip this step.** The `.gitconfig` ships with commit
+> signing **enabled** (`commit.gpgSign = true`); without a configured key,
+> every `git commit` fails. Create yours:
+>
+> ```sh
+> gpg --full-generate-key                        # RSA 4096; use the same e-mail as git
+> gpg --list-secret-keys --keyid-format=long     # copy the ID after "sec rsa4096/"
+> git config --global user.signingkey <ID>
+> gpg --armor --export <ID>                      # paste into GitHub → Settings → SSH and GPG keys
+> ```
+>
+> Don't want signed commits? Turn it off for good:
+> `git config --global commit.gpgsign false`
+
 **4. Open a new terminal** (or `exec zsh`) and **validate** everything is in place:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -122,6 +122,20 @@ O `just bootstrap` é **idempotente** (pode rodar quantas vezes quiser) e execut
 [Faça seu fork](#faça-seu-fork-torne-seu)): nome/e-mail do git em `~/.gitconfig`,
 chave do WakaTime em `~/.wakatime.cfg` e os segredos em `~/.zshrc.local`.
 
+> 🔑 **Chave GPG — não pule esta etapa.** O `.gitconfig` vem com assinatura de
+> commits **ligada** (`commit.gpgSign = true`); sem uma chave configurada, todo
+> `git commit` falha. Crie a sua:
+>
+> ```sh
+> gpg --full-generate-key                        # RSA 4096; use o mesmo e-mail do git
+> gpg --list-secret-keys --keyid-format=long     # copie o ID após "sec rsa4096/"
+> git config --global user.signingkey <ID>
+> gpg --armor --export <ID>                      # cole no GitHub → Settings → SSH and GPG keys
+> ```
+>
+> Não quer assinar commits? Desligue de vez:
+> `git config --global commit.gpgsign false`
+
 **4. Abra um novo terminal** (ou `exec zsh`) e **valide** que está tudo no lugar:
 
 ```sh

--- a/dotfiles/.gitconfig
+++ b/dotfiles/.gitconfig
@@ -11,6 +11,9 @@
 	process = git-lfs filter-process
 	clean = git-lfs clean -- %f
 	required = true
+# Assinatura de commits ligada por padrão: exige uma chave GPG configurada.
+# Crie a sua (gpg --full-generate-key) e preencha user.signingKey acima, ou
+# desligue com: git config --global commit.gpgsign false
 [commit]
 	gpgSign = true
 [tag]

--- a/dotfiles/.opentofurc
+++ b/dotfiles/.opentofurc
@@ -1,6 +1,10 @@
-provider_installation {
-  network_mirror {
-    url = "ssh://git@github.com/"
-    match = "github.com"
-  }
-}
+# Config do CLI do OpenTofu (symlinkado para ~/.opentofurc pelo `just link`).
+# Hoje sem customização — o default (registry.opentofu.org) atende.
+#
+# Se um dia precisar de mirror de providers (ex.: rede corporativa), o formato é:
+#   provider_installation {
+#     network_mirror {
+#       url = "https://<mirror-host>/providers/"   # precisa ser HTTPS e terminar em /
+#     }
+#   }
+# Docs: https://opentofu.org/docs/cli/config/config-file/

--- a/dotfiles/.zshrc
+++ b/dotfiles/.zshrc
@@ -121,7 +121,12 @@ plugins=(
     yarn
     )
 
-source $ZSH/oh-my-zsh.sh
+# Guard: sem oh-my-zsh o shell segue funcionando (instale com `just omz`)
+if [ -f "$ZSH/oh-my-zsh.sh" ]; then
+  source "$ZSH/oh-my-zsh.sh"
+else
+  echo "big-bang: oh-my-zsh não encontrado em $ZSH — rode 'just omz' no repo" >&2
+fi
 
 # User configuration
 

--- a/justfile
+++ b/justfile
@@ -11,9 +11,17 @@ default:
     @just --list
 
 # Full setup on a new machine (idempotent)
-bootstrap: brew link mise-install seed podman-machine
+bootstrap: brew omz link mise-install seed podman-machine
     @echo ""
     @echo "✅ Bootstrap complete. Open a new terminal (or run: exec zsh)."
+
+# Install oh-my-zsh if missing (the .zshrc expects it; idempotent)
+omz:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [[ -d "$HOME/.oh-my-zsh" ]]; then echo "ok     oh-my-zsh already installed"; exit 0; fi
+    echo "→ installing oh-my-zsh"
+    RUNZSH=no KEEP_ZSHRC=yes sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
 
 # Install/upgrade everything in the Brewfile
 brew:
@@ -62,25 +70,32 @@ seed:
     just _seed "{{ repo }}/claude/usage-budget.example"   "{{ home }}/.claude/usage-budget"
     @echo "→ Now fill identity/keys in ~/.gitconfig, ~/.wakatime.cfg and ~/.zshrc.local"
     @echo "→ Set your monthly token limit (US\$) in ~/.claude/usage-budget"
+    @echo "→ GPG: commits são assinados por padrão — crie uma chave (gpg --full-generate-key)"
+    @echo "  e preencha user.signingKey, ou rode: git config --global commit.gpgsign false"
 
 # Update the Brewfile from what's currently installed
 brew-dump:
     brew bundle dump --force --file="{{ repo }}/Brewfile"
 
-# Sanity check: tools present + symlinks resolved
+# Sanity check: tools present + symlinks resolved (exit 1 on any failure)
 doctor:
     #!/usr/bin/env bash
     set -uo pipefail
+    fail=0
     echo "## tools"
-    for t in brew mise nvim starship fzf git just podman; do
-      printf "  %-10s %s\n" "$t" "$(command -v "$t" || echo MISSING)"
+    for t in brew mise nvim starship fzf git just podman gh jq gpg git-lfs; do
+      if p="$(command -v "$t")"; then printf "  %-10s %s\n" "$t" "$p"; else printf "  %-10s MISSING\n" "$t"; fail=1; fi
     done
     echo "## podman"
     printf "  machine    %s\n" "$(podman machine inspect podman-machine-default --format '{{{{.State}}' 2>/dev/null || echo 'NOT INITIALIZED (run: just podman-machine)')"
     echo "## symlinks"
-    for f in "{{ home }}/.zshrc" "{{ home }}/.config/starship.toml" "{{ home }}/.config/nvim" "{{ home }}/.config/mise/config.toml"; do
-      if [[ -L "$f" ]]; then echo "  ok   $f -> $(readlink "$f")"; else echo "  NOT A SYMLINK: $f"; fi
+    for f in "{{ home }}/.zshrc" "{{ home }}/.gitignore.global" "{{ home }}/.opentofurc" \
+             "{{ home }}/.config/starship.toml" "{{ home }}/.config/nvim" \
+             "{{ home }}/.config/mise/config.toml" "{{ home }}/.config/wezterm/wezterm.lua" \
+             "{{ home }}/.config/ghostty/config" "{{ home }}/.config/cmux/cmux.json"; do
+      if [[ -L "$f" ]]; then echo "  ok   $f -> $(readlink "$f")"; else echo "  NOT A SYMLINK: $f"; fail=1; fi
     done
+    exit $fail
 
 # Open a PR for the current branch in the browser (requires: gh auth login)
 pr:
@@ -114,4 +129,6 @@ _seed src dst:
     set -euo pipefail
     src="{{ src }}"; dst="{{ dst }}"
     if [[ -e "$dst" ]]; then echo "keep   $dst (already exists)"; exit 0; fi
-    mkdir -p "$(dirname "$dst")"; cp "$src" "$dst"; echo "seed   $dst"
+    mkdir -p "$(dirname "$dst")"; cp "$src" "$dst"
+    # Arquivos seedados recebem identidade/tokens — nascem legíveis só pelo dono
+    chmod 600 "$dst"; echo "seed   $dst"


### PR DESCRIPTION
## O que muda

Correções para o `just bootstrap` produzir uma máquina realmente funcional (hoje há 4 furos que quebram máquina nova):

- **Brewfile**: `jq` (dependência dura de `claude/statusline.sh`/`usage.sh`), `git-lfs` (o `.gitconfig` tem filtro `required = true`), `gnupg` + `pinentry-mac` (o `.gitconfig` liga `gpgSign`), `pre-commit`
- **oh-my-zsh**: nunca era instalado por nada e o `.zshrc` fazia `source` sem guard → primeira abertura de shell falhava. Agora: guard com aviso + receita `just omz` (idempotente) no `bootstrap`
- **`.opentofurc`**: `network_mirror { url = "ssh://..." }` é formato inválido (exige HTTPS) e quebrava `tofu init` — removido, arquivo documentado
- **`.zshrc`**: remove lixo de instalador de terceiro (PATH com `/Users/U004334` hardcoded, duplicando linha existente com `$HOME` + aliases litellm apontando para paths não gerenciados)
- **`just doctor`**: agora checa `gh`/`jq`/`gpg`/`git-lfs` + os 9 symlinks do `link` e **retorna exit 1** em falha (vira gate utilizável)
- **`_seed`**: `chmod 600` no destino (todos os arquivos seedados carregam identidade/tokens)
- **GPG**: comentário no `.gitconfig` + aviso no `seed` orientando criar chave ou desligar assinatura

## Verificação

- `zsh -n dotfiles/.zshrc` ✓ · `just --summary` ✓ · shell interativo abre ✓
- `just doctor` nesta máquina: exit 0 com tudo presente; exit 1 confirmado quando gpg/git-lfs faltavam

🤖 Generated with [Claude Code](https://claude.com/claude-code)