### PR TITLE
fix(fork): remove caminhos fixos do autor — funciona em qualquer clone

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -89,6 +89,8 @@ committed secrets — only *templates* — but several defaults are mine:
 | **Packages** | [`Brewfile`](./Brewfile) | add/remove apps and CLIs to taste |
 | **Editor languages** | [`nvim/`](./nvim) | Neovim ships ready for **Go, .NET/C# and Kotlin**; adapt the LSPs to your stack |
 | **Toolchains** | [`mise/config.toml`](./mise/config.toml) | Go/Java/Node/… versions that get installed |
+| **Clone path** | nothing, if you use `just seed`/`just link` | the Claude statusline ([`claude/settings.json`](./claude/settings.json)) and the WezTerm status discover the clone by themselves; if something fails, set `BIG_BANG_REPO` in `~/.zshrc.local` |
+| **npm token** | `~/.npmrc` (after `just seed`) | the template ([`dotfiles/.npmrc`](./dotfiles/.npmrc)) reads `NPM_TOKEN` from the environment — set it in `~/.zshrc.local` if you use a private registry |
 
 > 💡 **Golden rule:** files with identity/secrets are only *copied* (`just seed`)
 > and **never** overwritten nor committed back — so you can edit them freely in

--- a/README-en.md
+++ b/README-en.md
@@ -55,8 +55,9 @@ For those who already know what they're doing (first time? jump to
 # 2. just
 brew install just
 
-# 3. clone + bootstrap (idempotent)
-git clone git@github.com:marcopollivier/big-bang.git && cd big-bang
+# 3. clone (following the ~/dev/<github-user>/<project> convention) + bootstrap (idempotent)
+git clone git@github.com:marcopollivier/big-bang.git ~/dev/marcopollivier/big-bang
+cd ~/dev/marcopollivier/big-bang
 just bootstrap
 
 # 4. fill in identity/secrets and validate
@@ -89,7 +90,7 @@ committed secrets — only *templates* — but several defaults are mine:
 | **Packages** | [`Brewfile`](./Brewfile) | add/remove apps and CLIs to taste |
 | **Editor languages** | [`nvim/`](./nvim) | Neovim ships ready for **Go, .NET/C# and Kotlin**; adapt the LSPs to your stack |
 | **Toolchains** | [`mise/config.toml`](./mise/config.toml) | Go/Java/Node/… versions that get installed |
-| **Clone path** | nothing, if you use `just seed`/`just link` | the Claude statusline ([`claude/settings.json`](./claude/settings.json)) and the WezTerm status discover the clone by themselves; if something fails, set `BIG_BANG_REPO` in `~/.zshrc.local` |
+| **Clone path** | nothing, if you use `just seed`/`just link` | the Claude statusline ([`claude/settings.json`](./claude/settings.json)) and the WezTerm status discover the clone by themselves (fallback: the `~/dev/<github-user>/big-bang` convention); if something fails, set `BIG_BANG_REPO` in `~/.zshrc.local` |
 | **npm token** | `~/.npmrc` (after `just seed`) | the template ([`dotfiles/.npmrc`](./dotfiles/.npmrc)) reads `NPM_TOKEN` from the environment — set it in `~/.zshrc.local` if you use a private registry |
 
 > 💡 **Golden rule:** files with identity/secrets are only *copied* (`just seed`)
@@ -107,9 +108,16 @@ brew install just
 **2. Clone your fork and bootstrap:**
 
 ```sh
-git clone git@github.com:<you>/big-bang.git && cd big-bang
+git clone git@github.com:<you>/big-bang.git ~/dev/<you>/big-bang
+cd ~/dev/<you>/big-bang
 just bootstrap
 ```
+
+> 📁 **Folder convention:** projects live in `~/dev/<owner>/<project>` — the
+> owner is the GitHub user/org (e.g. `~/dev/<you>/big-bang`). Only dotfiles go
+> in the home root (`~/`), via symlink/seed. It's not mandatory (everything is
+> auto-discovered, and `BIG_BANG_REPO` covers exceptions), but it's the pattern
+> the repo assumes as a fallback.
 
 `just bootstrap` is **idempotent** (run it as many times as you like) and runs:
 

--- a/README.md
+++ b/README.md
@@ -55,8 +55,9 @@ Pra quem já sabe o que está fazendo (primeira vez? pule para
 # 2. just
 brew install just
 
-# 3. clone + bootstrap (idempotente)
-git clone git@github.com:marcopollivier/big-bang.git && cd big-bang
+# 3. clone (na convenção ~/dev/<github-user>/<projeto>) + bootstrap (idempotente)
+git clone git@github.com:marcopollivier/big-bang.git ~/dev/marcopollivier/big-bang
+cd ~/dev/marcopollivier/big-bang
 just bootstrap
 
 # 4. preencha identidade/segredos e valide
@@ -89,7 +90,7 @@ tem segredo versionado — só *templates* — mas vários defaults são meus:
 | **Pacotes** | [`Brewfile`](./Brewfile) | tire/ponha apps e CLIs conforme o seu gosto |
 | **Linguagens do editor** | [`nvim/`](./nvim) | o Neovim vem pronto pra **Go, .NET/C# e Kotlin**; adapte os LSPs ao seu stack |
 | **Toolchains** | [`mise/config.toml`](./mise/config.toml) | versões de Go/Java/Node/… que serão instaladas |
-| **Caminho do clone** | nenhum, se usar `just seed`/`just link` | o statusline do Claude ([`claude/settings.json`](./claude/settings.json)) e o status do WezTerm descobrem o clone sozinhos; se algo falhar, defina `BIG_BANG_REPO` no `~/.zshrc.local` |
+| **Caminho do clone** | nenhum, se usar `just seed`/`just link` | o statusline do Claude ([`claude/settings.json`](./claude/settings.json)) e o status do WezTerm descobrem o clone sozinhos (fallback: convenção `~/dev/<github-user>/big-bang`); se algo falhar, defina `BIG_BANG_REPO` no `~/.zshrc.local` |
 | **Token do npm** | `~/.npmrc` (após `just seed`) | o template ([`dotfiles/.npmrc`](./dotfiles/.npmrc)) lê `NPM_TOKEN` do ambiente — defina no `~/.zshrc.local` se usa registry privado |
 
 > 💡 **Regra de ouro:** os arquivos com identidade/segredo são apenas *copiados*
@@ -108,9 +109,16 @@ brew install just
 **2. Clone o seu fork e rode o bootstrap:**
 
 ```sh
-git clone git@github.com:<você>/big-bang.git && cd big-bang
+git clone git@github.com:<você>/big-bang.git ~/dev/<você>/big-bang
+cd ~/dev/<você>/big-bang
 just bootstrap
 ```
+
+> 📁 **Convenção de pastas:** projetos vivem em `~/dev/<dono>/<projeto>` — o
+> dono é o usuário/org do GitHub (ex.: `~/dev/<você>/big-bang`). Só os dotfiles
+> ficam na raiz da home (`~/`), via symlink/seed. Não é obrigatório (tudo se
+> descobre sozinho, e `BIG_BANG_REPO` cobre exceções), mas é o padrão que o
+> repo assume como fallback.
 
 O `just bootstrap` é **idempotente** (pode rodar quantas vezes quiser) e executa:
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ tem segredo versionado — só *templates* — mas vários defaults são meus:
 | **Pacotes** | [`Brewfile`](./Brewfile) | tire/ponha apps e CLIs conforme o seu gosto |
 | **Linguagens do editor** | [`nvim/`](./nvim) | o Neovim vem pronto pra **Go, .NET/C# e Kotlin**; adapte os LSPs ao seu stack |
 | **Toolchains** | [`mise/config.toml`](./mise/config.toml) | versões de Go/Java/Node/… que serão instaladas |
+| **Caminho do clone** | nenhum, se usar `just seed`/`just link` | o statusline do Claude ([`claude/settings.json`](./claude/settings.json)) e o status do WezTerm descobrem o clone sozinhos; se algo falhar, defina `BIG_BANG_REPO` no `~/.zshrc.local` |
+| **Token do npm** | `~/.npmrc` (após `just seed`) | o template ([`dotfiles/.npmrc`](./dotfiles/.npmrc)) lê `NPM_TOKEN` do ambiente — defina no `~/.zshrc.local` se usa registry privado |
 
 > 💡 **Regra de ouro:** os arquivos com identidade/segredo são apenas *copiados*
 > (`just seed`) e **nunca** sobrescritos nem versionados de volta — então pode

--- a/claude/README.md
+++ b/claude/README.md
@@ -7,7 +7,7 @@ consumo de tokens.
 
 | Arquivo | O que é |
 |---|---|
-| `settings.json` | **Modelo** das settings do Claude Code (sem nada da empresa). Seedado para `~/.claude/settings.json` pelo `just seed` — só se não existir. |
+| `settings.json` | **Modelo** das settings do Claude Code (sem nada da empresa). Seedado para `~/.claude/settings.json` pelo `just seed` — só se não existir. O placeholder `__REPO__` do statusline é trocado pelo caminho real do clone na cópia (por isso, se copiar à mão, troque você mesmo). |
 | `statusline.sh` | Statusline **dentro** do Claude Code: `modelo · $custo-sessão · branch✓/✗ · %contexto · %5h · %7d · $mês/$limite`. O gasto do mês reaproveita o `usage.sh` (mesma fonte/cores do WezTerm). Ligado pela chave `statusLine` do `settings.json`. |
 | `usage.sh` | Consumo do **mês** vs o limite mensal + gasto de hoje + projeção do fechamento (`$59/$300 · 20% · hoje $9 · proj $295`). Usado pelo statusline e pelo `right_status` do WezTerm. |
 | `usage-budget.example` | Modelo do limite mensal. Seedado para `~/.claude/usage-budget` (local, **fora do git**, como o `~/.zshrc.local`). |

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -4,7 +4,7 @@
   "theme": "dark",
   "statusLine": {
     "type": "command",
-    "command": "$HOME/dev/marcopollivier/big-bang/claude/statusline.sh",
+    "command": "__REPO__/claude/statusline.sh",
     "padding": 0
   }
 }

--- a/claude/usage.sh
+++ b/claude/usage.sh
@@ -15,10 +15,18 @@
 # Cache (TTL 120s) + refresh em background: cada tick do WezTerm só lê um arquivo.
 # ---------------------------------------------------------------------------
 
+# ccusage: shim do mise no caminho padrão; senão, o que estiver no PATH.
 ccusage_bin="$HOME/.local/share/mise/shims/ccusage"
+[ -x "$ccusage_bin" ] || ccusage_bin="$(command -v ccusage || true)"
 cache="${TMPDIR:-/tmp}/claude-usage"
 budget_file="$HOME/.claude/usage-budget"
 ttl=120
+
+# Sem ccusage ou jq não há como medir: mostra "?" em vez de um falso "$0".
+if [ -z "$ccusage_bin" ] || ! command -v jq >/dev/null 2>&1; then
+  printf '?'
+  exit 0
+fi
 
 # Primeiro número no arquivo de limite (ignora linhas de comentário com #).
 read_budget() {

--- a/dotfiles/.zshrc.local.example
+++ b/dotfiles/.zshrc.local.example
@@ -16,3 +16,7 @@
 ## Contextos EKS usados por k8s-p / k8s-h (ARNs da sua infra)
 # export EKS_PRD_ARN="arn:aws:eks:<region>:<account-id>:cluster/<cluster-prd>"
 # export EKS_HML_ARN="arn:aws:eks:<region>:<account-id>:cluster/<cluster-hml>"
+
+## Caminho deste clone (só se a descoberta automática falhar — o WezTerm resolve
+## o symlink do próprio wezterm.lua; ver wezterm/.wezterm.lua)
+# export BIG_BANG_REPO="$HOME/dev/<seu-usuario>/big-bang"

--- a/justfile
+++ b/justfile
@@ -66,7 +66,7 @@ seed:
     just _seed "{{ repo }}/dotfiles/.aws/config"          "{{ home }}/.aws/config"
     just _seed "{{ repo }}/dotfiles/.npmrc"               "{{ home }}/.npmrc"
     just _seed "{{ repo }}/dotfiles/.clojure/deps.edn"    "{{ home }}/.clojure/deps.edn"
-    just _seed "{{ repo }}/claude/settings.json"          "{{ home }}/.claude/settings.json"
+    just _seed_template "{{ repo }}/claude/settings.json" "{{ home }}/.claude/settings.json"
     just _seed "{{ repo }}/claude/usage-budget.example"   "{{ home }}/.claude/usage-budget"
     @echo "→ Now fill identity/keys in ~/.gitconfig, ~/.wakatime.cfg and ~/.zshrc.local"
     @echo "→ Set your monthly token limit (US\$) in ~/.claude/usage-budget"
@@ -131,4 +131,15 @@ _seed src dst:
     if [[ -e "$dst" ]]; then echo "keep   $dst (already exists)"; exit 0; fi
     mkdir -p "$(dirname "$dst")"; cp "$src" "$dst"
     # Arquivos seedados recebem identidade/tokens — nascem legíveis só pelo dono
+    chmod 600 "$dst"; echo "seed   $dst"
+
+# Como _seed, mas substitui __REPO__ pelo caminho real deste clone — assim o
+# template funciona em qualquer fork/diretório, sem caminho fixo do autor
+_seed_template src dst:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    src="{{ src }}"; dst="{{ dst }}"
+    if [[ -e "$dst" ]]; then echo "keep   $dst (already exists)"; exit 0; fi
+    mkdir -p "$(dirname "$dst")"
+    sed "s|__REPO__|{{ repo }}|g" "$src" >"$dst"
     chmod 600 "$dst"; echo "seed   $dst"

--- a/wezterm/.wezterm.lua
+++ b/wezterm/.wezterm.lua
@@ -110,7 +110,8 @@ config.keys = {
 -- Onde está o clone deste repo? Sem caminho fixo do autor: o wezterm.lua da
 -- home é um symlink para <repo>/wezterm/.wezterm.lua (criado pelo `just link`),
 -- então resolver o link revela o clone — funciona em qualquer fork/diretório.
--- Ordem: $BIG_BANG_REPO (override manual) → symlink resolvido → caminho padrão.
+-- Ordem: $BIG_BANG_REPO (override manual) → symlink resolvido → convenção
+-- de pastas do repo (~/dev/<github-user>/big-bang, ver README).
 local function repo_dir()
   local override = os.getenv("BIG_BANG_REPO")
   if override and override ~= "" then
@@ -127,12 +128,16 @@ local function repo_dir()
       end
     end
   end
-  return wezterm.home_dir .. "/dev/marcopollivier/big-bang"
+  for _, dir in ipairs(wezterm.glob(wezterm.home_dir .. "/dev/*/big-bang")) do
+    return dir
+  end
+  return nil
 end
 
+-- Sem clone encontrado (nem override): status bars ficam vazios, sem erro.
 local repo = repo_dir()
-local usage_script = repo .. "/claude/usage.sh"
-local sysinfo_script = repo .. "/wezterm/sysinfo.sh"
+local usage_script = repo and (repo .. "/claude/usage.sh")
+local sysinfo_script = repo and (repo .. "/wezterm/sysinfo.sh")
 
 -- Cor por nível de uso (verde → amarelo → laranja → vermelho).
 local function level_color(pct, yellow, orange, red)
@@ -149,6 +154,11 @@ local function level_color(pct, yellow, orange, red)
 end
 
 wezterm.on("update-status", function(window, _pane)
+  if not repo then
+    window:set_right_status("")
+    window:set_left_status("")
+    return
+  end
   -- Direita: consumo do Claude Code. Cor pela % do limite (60/70/85).
   local ok, usage = wezterm.run_child_process({ usage_script })
   usage = (ok and usage or ""):gsub("%s+$", "")

--- a/wezterm/.wezterm.lua
+++ b/wezterm/.wezterm.lua
@@ -106,7 +106,31 @@ config.keys = {
 --             mês vs limite + hoje + projeção; estimativa local via ccusage, bate
 --             com a UI do Claude; limite em ~/.claude/usage-budget).
 -- Ambos os scripts têm cache próprio, então cada tick aqui é barato.
-local repo = wezterm.home_dir .. "/dev/marcopollivier/big-bang"
+
+-- Onde está o clone deste repo? Sem caminho fixo do autor: o wezterm.lua da
+-- home é um symlink para <repo>/wezterm/.wezterm.lua (criado pelo `just link`),
+-- então resolver o link revela o clone — funciona em qualquer fork/diretório.
+-- Ordem: $BIG_BANG_REPO (override manual) → symlink resolvido → caminho padrão.
+local function repo_dir()
+  local override = os.getenv("BIG_BANG_REPO")
+  if override and override ~= "" then
+    return override
+  end
+  local f = io.popen('readlink -f "' .. wezterm.config_file .. '" 2>/dev/null')
+  if f then
+    local resolved = f:read("*l")
+    f:close()
+    if resolved and resolved ~= "" then
+      local dir = resolved:match("^(.*)/wezterm/[^/]+$")
+      if dir then
+        return dir
+      end
+    end
+  end
+  return wezterm.home_dir .. "/dev/marcopollivier/big-bang"
+end
+
+local repo = repo_dir()
 local usage_script = repo .. "/claude/usage.sh"
 local sysinfo_script = repo .. "/wezterm/sysinfo.sh"
 


### PR DESCRIPTION
## O que muda

Dois hardcodes duplicados de `~/dev/marcopollivier/big-bang` faziam o statusline do Claude Code e os status bars do WezTerm falharem **em silêncio** em qualquer fork ou clone fora do caminho padrão — e a tabela "Faça seu fork" não avisava.

- **`claude/settings.json`**: o comando do statusline vira placeholder `__REPO__`; a nova receita interna `_seed_template` resolve para o caminho real do clone na hora do `just seed` (continua never-clobber)
- **`wezterm/.wezterm.lua`**: o repo é descoberto resolvendo o symlink do próprio config (`wezterm.config_file` + `readlink -f`), com override manual via `$BIG_BANG_REPO` e fallback para o caminho padrão
- **`claude/usage.sh`**: fallback para `ccusage` no PATH quando o shim do mise não existe + guard de `jq`; sem como medir, mostra `?` em vez de um falso `$0/$300 · 0%`
- **READMEs (PT+EN)**: tabela "Faça seu fork" ganha as linhas "Caminho do clone" e "Token do npm"; `BIG_BANG_REPO` documentado no `.zshrc.local.example`

## Verificação

- `just seed` em `HOME` temporário: settings.json gerado aponta para o clone real ✓
- `wezterm ls-fonts/show-keys` carregando o config via symlink da home: resolve o repo corretamente ✓
- `bash -n claude/usage.sh` ✓ · `just --summary` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)