### PR TITLE
docs: alinha documentação com a realidade do repo

### DIFF
--- a/.claude/skills/machine-bootstrap/SKILL.md
+++ b/.claude/skills/machine-bootstrap/SKILL.md
@@ -22,7 +22,10 @@ nova pronta com o mínimo de esforço, sem expor segredos.
    - `brew install just`
 
 2. **Bootstrap** (na raiz do repo)
-   - `just bootstrap` = `brew` (instala o Brewfile) → `link` → `mise-install` → `seed`.
+   - `just bootstrap` compõe as sub-recipes na ordem do `justfile` — hoje:
+     `brew` (Brewfile) → `link` (symlinks) → `mise-install` → `seed` →
+     `podman-machine` (cria/inicia a VM Linux do podman). Confira `just --list`
+     se a composição mudar.
    - `mise-install` já roda `mise trust` no `mise/config.toml` do repo, então entrar na
      pasta não dispara o erro de config não confiada. Se mesmo assim aparecer
      `Config files ... are not trusted`, rode `mise trust mise/config.toml`.
@@ -32,6 +35,9 @@ nova pronta com o mínimo de esforço, sem expor segredos.
    - Git: `git config --global user.name`, `user.email`, `user.signingkey` (assinatura GPG está ligada no `.gitconfig`).
    - `~/.zshrc.local`: `AWS_*`, `GITHUB_TOKEN`, `EKS_PRD_ARN`, `EKS_HML_ARN` — modelo em `dotfiles/.zshrc.local.example`.
    - WakaTime: dentro do `nvim`, `:WakaTimeApiKey` (chave em https://wakatime.com/settings/api-key).
+   - Claude Code: limite mensal (US$) em `~/.claude/usage-budget` — trabalho: o
+     limite dado; pessoal/Pro: `0` (mostra só o gasto). Opcional: `just ruflo`
+     instala o plugin ruflo (requer a CLI `claude`).
 
 4. **Autenticações interativas** (não dá pra rodar headless)
    - `gh auth login` — peça ao usuário rodar com `! gh auth login --git-protocol ssh --web`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,14 +1,24 @@
 # Big Bang — guia para o Claude
 
 Repositório de **dotfiles / configuração de máquina (macOS)**. É a fonte de verdade
-do meu ambiente; o setup é feito com [`just`](./justfile) (sem provisionador pesado).
+do ambiente; o setup é feito com [`just`](./justfile) (sem provisionador pesado).
+
+**Escopo do projeto:** serve para **qualquer ambiente — uso pessoal ou
+profissional** — e foi pensado para ser forkado e adaptado. O foco é **macOS**
+(*macOS-first*): outros sistemas operacionais podem entrar no futuro, mas **não
+são escopo agora** — não adicione suporte a Linux/Windows sem pedido explícito.
 
 ## Estrutura
 - `dotfiles/` — dotfiles da home (templates, **sem segredos**)
-- `nvim/` — Neovim como IDE (Go/.NET/Kotlin); detalhes em `nvim/SETUP.md`
+- `nvim/` — Neovim como IDE (Go/.NET/Kotlin); atalhos em `nvim/README.md`,
+  histórico/racional em `nvim/SETUP.md`, treino guiado em `nvim/PRACTICE.md`
 - `wezterm/`, `starship/`, `mise/` — terminal, prompt e toolchains
 - `cmux/` — orquestrador de agentes de IA (terminal via Ghostty embutido); em teste como alternativa ao WezTerm. Detalhes em `cmux/README.md`
 - `claude/` — config do Claude Code + acompanhamento de consumo de tokens (statusline + status do mês no WezTerm); detalhes em `claude/README.md`
+- `defaultdots/` — dotfiles de fábrica, referência de reset (não são os do dia a dia)
+- `.claude/` — skills e slash commands deste repo: `/setup-machine` (configura a
+  máquina do zero), `/sync` (re-sincroniza symlinks/Brewfile e reporta divergências)
+  e a skill `machine-bootstrap`
 - `Brewfile` — pacotes Homebrew · `justfile` — bootstrap/manutenção
 - `.github/workflows/ci.yml` — CI (lint + gitleaks)
 
@@ -19,6 +29,8 @@ do meu ambiente; o setup é feito com [`just`](./justfile) (sem provisionador pe
   arquivo real). Editar no repo reflete na máquina, e vice-versa.
 - Templates com identidade/segredo (`.gitconfig`, `.wakatime.cfg`) são copiados
   **só se não existirem** via `just seed` — nunca sobrescreva-os.
+- **Docs bilíngues:** toda mudança em `README.md` deve ser espelhada em
+  `README-en.md` (e vice-versa) — mesma estrutura de seções, mesmo conteúdo.
 - O Lua de `nvim/` é formatado com `stylua` (o CI checa). Rode `stylua nvim/` antes de commitar.
 - **Não dê push direto na `main`.** Trabalhe em branch e abra PR com `just pr` (usa o `gh`).
 - **Uma branch por escopo.** Antes de começar qualquer trabalho cujo assunto seja
@@ -30,4 +42,4 @@ do meu ambiente; o setup é feito com [`just`](./justfile) (sem provisionador pe
 ## Setup de máquina nova
 Use o comando **`/setup-machine`** (ou deixe a skill *machine-bootstrap* guiar). Em resumo:
 `brew install just` → `just bootstrap` → preencher segredos/identidade → `gh auth login`
-→ validar com `just doctor`.
+→ validar com `just doctor`. Para re-sincronizar uma máquina existente, use **`/sync`**.

--- a/README-en.md
+++ b/README-en.md
@@ -114,7 +114,7 @@ just bootstrap
 - `just brew` — install everything in the [`Brewfile`](./Brewfile)
 - `just link` — symlink the shared configs (zsh, starship, nvim, mise…); existing real files are backed up first
 - `just mise-install` — install the toolchains from [`mise/config.toml`](./mise/config.toml)
-- `just seed` — copy secret/identity templates (`.gitconfig`, `.wakatime.cfg`, `~/.zshrc.local`) **only if missing**
+- `just seed` — copy secret/identity templates **only if missing**: `.gitconfig`, `.wakatime.cfg`, `~/.zshrc.local`, `~/.npmrc`, `~/.aws/config`, `~/.clojure/deps.edn` and the two Claude Code ones (`~/.claude/settings.json` and `~/.claude/usage-budget` — see [`claude/`](./claude))
 - `just podman-machine` — create/start the podman Linux VM (on macOS containers run inside it)
 
 **3. Fill in your identity and secrets** (see the table in
@@ -159,6 +159,8 @@ Run `just` (no arguments) to list all recipes. The most-used ones:
 | [`wezterm/`](./wezterm) | [WezTerm](https://wezfurlong.org/wezterm/) terminal configuration. |
 | [`starship/`](./starship) | [Starship](https://starship.rs/) shell prompt configuration. |
 | [`mise/`](./mise) | Global [mise](https://mise.jdx.dev/) config — toolchain versions. |
+| [`claude/`](./claude) | [Claude Code](https://claude.com/claude-code) config + token-usage tracking (statusline and month status in WezTerm). See its [`README`](./claude/README.md). |
+| [`cmux/`](./cmux) | AI agent orchestrator (embedded Ghostty terminal), being tried as a WezTerm alternative. See its [`README`](./cmux/README.md). |
 | [`defaultdots/`](./defaultdots) | Pristine/original dotfiles, kept as a reset reference. |
 
 Each folder has its own `README.md`. Root files worth knowing:
@@ -167,11 +169,14 @@ Each folder has its own `README.md`. Root files worth knowing:
 - [`Brewfile`](./Brewfile) — Homebrew packages (`brew bundle`).
 - [`.pre-commit-config.yaml`](./.pre-commit-config.yaml) — local quality/secret hooks.
 - [`.github/workflows/ci.yml`](./.github/workflows/ci.yml) — CI (lint, syntax, secret scan).
+- `.claude/` — slash commands for Claude Code users in this repo:
+  **`/setup-machine`** (guided from-scratch machine setup) and **`/sync`**
+  (re-syncs symlinks/Brewfile and reports drift).
 
 ## Tooling / stack
 
 - **Version manager:** [mise](https://mise.jdx.dev/) — Go, Java, Kotlin, Node,
-  .NET, Python… (replaced asdf/nvm/pyenv).
+  .NET… (replaced asdf/nvm/pyenv). See [`mise/config.toml`](./mise/config.toml).
 - **Packages:** [Homebrew](https://brew.sh/) (see [`Brewfile`](./Brewfile)).
 - **Shell:** zsh + oh-my-zsh, **Starship** prompt.
 - **Editor:** Neovim (see [`nvim/`](./nvim)).
@@ -209,6 +214,11 @@ both at once** — there is no sync step:
 To re-apply or repair the links after adding a new config, just run `just link`
 again.
 
+> ⚠️ **Symlink side effect:** installers that do `>> ~/.zshrc` (many CLIs do)
+> write **straight into the repo's versioned file**. Before committing, check
+> `git diff` — move anything machine-specific to `~/.zshrc.local` instead of
+> leaving it in the repo's `.zshrc`.
+
 ### How it stays safe (no secret leaks)
 
 The trick is that **only secret-free files are symlinked and committed**.
@@ -217,7 +227,7 @@ Anything that carries identity or credentials is handled differently:
 | Kind of file | Strategy | Committed? | Examples |
 |---|---|---|---|
 | Shared, **secret-free** config | **symlink** (`just link`) | ✅ yes | `.zshrc`, `starship.toml`, `nvim/`, `mise/config.toml` |
-| Identity / secret-bearing | **seed** — copied **only if missing** (`just seed`), never overwritten | ❌ no | `.gitconfig`, `.wakatime.cfg` |
+| Identity / secret-bearing | **seed** — copied **only if missing** (`just seed`), never overwritten | ❌ no | `.gitconfig`, `.wakatime.cfg`, `.npmrc` |
 | Pure secrets / machine-specific | kept in a **git-ignored** file you fill in by hand | ❌ no | `~/.zshrc.local` |
 
 So the layered protection is:

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ O `just bootstrap` é **idempotente** (pode rodar quantas vezes quiser) e execut
 - `just brew` — instala tudo que está no [`Brewfile`](./Brewfile)
 - `just link` — cria os symlinks dos configs compartilhados (zsh, starship, nvim, mise…); arquivos reais existentes têm backup feito antes
 - `just mise-install` — instala os toolchains do [`mise/config.toml`](./mise/config.toml)
-- `just seed` — copia os templates de segredo/identidade (`.gitconfig`, `.wakatime.cfg`, `~/.zshrc.local`) **só se não existirem**
+- `just seed` — copia os templates de segredo/identidade **só se não existirem**: `.gitconfig`, `.wakatime.cfg`, `~/.zshrc.local`, `~/.npmrc`, `~/.aws/config`, `~/.clojure/deps.edn` e os dois do Claude Code (`~/.claude/settings.json` e `~/.claude/usage-budget` — veja [`claude/`](./claude))
 - `just podman-machine` — cria/inicia a VM Linux do podman (no macOS containers rodam dentro dela)
 
 **3. Preencha sua identidade e segredos** (veja a tabela em
@@ -160,6 +160,8 @@ Rode `just` (sem argumentos) para listar todas as recipes. As mais usadas:
 | [`wezterm/`](./wezterm) | Configuração do terminal [WezTerm](https://wezfurlong.org/wezterm/). |
 | [`starship/`](./starship) | Configuração do prompt [Starship](https://starship.rs/). |
 | [`mise/`](./mise) | Config global do [mise](https://mise.jdx.dev/) — versões dos toolchains. |
+| [`claude/`](./claude) | Config do [Claude Code](https://claude.com/claude-code) + acompanhamento de consumo de tokens (statusline e status do mês no WezTerm). Veja o [`README`](./claude/README.md). |
+| [`cmux/`](./cmux) | Orquestrador de agentes de IA (terminal Ghostty embutido), em teste como alternativa ao WezTerm. Veja o [`README`](./cmux/README.md). |
 | [`defaultdots/`](./defaultdots) | Dotfiles originais/de fábrica, mantidos como referência de reset. |
 
 Cada pasta tem o seu próprio `README.md`. Arquivos da raiz que vale conhecer:
@@ -168,11 +170,14 @@ Cada pasta tem o seu próprio `README.md`. Arquivos da raiz que vale conhecer:
 - [`Brewfile`](./Brewfile) — pacotes do Homebrew (`brew bundle`).
 - [`.pre-commit-config.yaml`](./.pre-commit-config.yaml) — hooks locais de qualidade/segredos.
 - [`.github/workflows/ci.yml`](./.github/workflows/ci.yml) — CI (lint, sintaxe, scan de segredos).
+- `.claude/` — slash commands para quem usa o Claude Code no repo:
+  **`/setup-machine`** (configura a máquina do zero, guiado) e **`/sync`**
+  (re-sincroniza symlinks/Brewfile e reporta divergências).
 
 ## Ferramentas / stack
 
 - **Gerenciador de versões:** [mise](https://mise.jdx.dev/) — Go, Java, Kotlin,
-  Node, .NET, Python… (substituiu asdf/nvm/pyenv).
+  Node, .NET… (substituiu asdf/nvm/pyenv). Veja o [`mise/config.toml`](./mise/config.toml).
 - **Pacotes:** [Homebrew](https://brew.sh/) (veja o [`Brewfile`](./Brewfile)).
 - **Shell:** zsh + oh-my-zsh, prompt **Starship**.
 - **Editor:** Neovim (veja [`nvim/`](./nvim)).
@@ -209,6 +214,11 @@ lados atualiza os dois de uma vez** — não existe passo de sincronização:
 
 Pra reaplicar ou consertar os links depois de adicionar um config novo, é só
 rodar `just link` de novo.
+
+> ⚠️ **Efeito colateral do symlink:** instaladores que fazem `>> ~/.zshrc`
+> (muitos CLIs fazem) escrevem **direto no arquivo versionado do repo**. Antes
+> de commitar, confira o `git diff` — mova o que for específico da máquina para
+> `~/.zshrc.local` em vez de deixar no `.zshrc` do repo.
 
 ### Como ele se mantém seguro (sem vazar segredos)
 

--- a/dotfiles/README.md
+++ b/dotfiles/README.md
@@ -14,7 +14,8 @@ máquina ficam em `~/.zshrc.local` (não versionado).
 | `.gitignore.global` | `.gitignore` global (referenciado por `core.excludesFile`). |
 | `.aws/config` | Config do AWS CLI (apenas região; sem credenciais). |
 | `.clojure/deps.edn` | Aliases globais do Clojure CLI. |
-| `.opentofurc` | Config do OpenTofu (network mirror de providers via SSH). |
+| `.npmrc` | Config do npm. O token de registry privado vem de `${NPM_TOKEN}` do ambiente (defina em `~/.zshrc.local`) — nunca do arquivo. |
+| `.opentofurc` | Config do CLI do OpenTofu. |
 | `.wakatime.cfg` | Config do WakaTime (tracking de tempo). `api_key` em branco — a chave real vai na máquina, não no repo. |
 
 ## Como instalar (máquina nova)

--- a/mise/README.md
+++ b/mise/README.md
@@ -19,4 +19,6 @@ mise use -g go@latest   # adiciona/fixa uma ferramenta (edita o config.toml)
 mise ls                 # lista o que está instalado
 ```
 
-Toolchains atuais: **Go, Java (Temurin 21), Kotlin, Node (LTS), .NET**.
+Toolchains atuais: **Go, Java (Temurin 21), Kotlin, Node (LTS), .NET** — mais o
+**`npm:ccusage`**, que alimenta o status de consumo do Claude no WezTerm e no
+statusline (ver [`../claude/`](../claude)).

--- a/nvim/PRACTICE.md
+++ b/nvim/PRACTICE.md
@@ -1,0 +1,169 @@
+# Treino de Neovim — esquentando os motores 🔥
+
+Guia **passo a passo e prático** pra pegar o dia a dia do Neovim com a config
+deste repo. Não é teoria: cada lição tem um **objetivo**, os **passos exatos** e
+uma **✅ missão** pra você fazer acontecer antes de avançar.
+
+> `<leader>` = **Espaço**. Atalhos completos em [`README.md`](./README.md);
+> racional do setup em [`SETUP.md`](./SETUP.md).
+
+## Como treinar
+1. Abra um terminal novo e rode **`nvim` dentro de um projeto** (Go sobe o LSP mais rápido — ótimo pra treinar).
+2. **Sem mouse e sem setas.** Mão foi pro mouse? Respira e volta pro `hjkl`.
+3. Faça **uma lição por sessão**, repita a missão até sair sem pensar. Marque o `[ ]` quando dominar.
+4. Meta não é velocidade — é **não precisar pensar**. Devagar e certo.
+
+---
+
+## 🌅 Aquecimento (5 min, todo dia, antes de tudo)
+Sempre os mesmos movimentos pra criar memória muscular:
+- Mover: `h j k l` · palavra `w b e` · início/fim de linha `0 ^ $` · topo/fim do arquivo `gg G`
+- Pular na linha: `f<char>` (vai até o char) · `;` repete · `,` repete pro outro lado
+- Desfazer/refazer: `u` / `<C-r>`
+
+✅ **Missão:** numa função real, vá do topo (`gg`) até o fim (`G`) e volte, mexendo só com `hjkl`/`w`/`b`. Use `f(` pra pular pro primeiro parêntese de cada linha.
+
+---
+
+## Lição 1 — Abrir e fechar arquivos
+**Objetivo:** entrar e sair de arquivos sem o mouse.
+
+| Ação | Como |
+|---|---|
+| Buscar e abrir arquivo | `<leader>ff` (ou `<leader><leader>`), digita parte do nome, `<Enter>` |
+| Salvar | `<leader>w` |
+| Fechar a janela atual | `<leader>q` |
+| Sair de tudo | `:qa` (`:qa!` descarta alterações) |
+
+✅ **Missão:** abra 3 arquivos diferentes com `<leader>ff`, salve um com `<leader>w` e feche-o com `<leader>q` — tudo sem tocar no mouse.
+
+---
+
+## Lição 2 — Árvore de arquivos (abrir, fechar, navegar)
+**Objetivo:** usar o **neo-tree** como barra lateral de arquivos.
+
+- `<leader>n` → **abre/fecha** a árvore (toggle).
+- Dentro da árvore (modo normal):
+  - `j`/`k` sobe/desce · `<Enter>` abre o arquivo/pasta
+  - `<C-l>` pula pro painel de código · `<C-h>` volta pra árvore
+- Pra criar/renomear arquivos pela árvore, veja a **Lição 6**.
+
+✅ **Missão:** abra a árvore com `<leader>n`, navegue até um arquivo em outra pasta, abra-o com `<Enter>`, pule pro código com `<C-l>` e feche a árvore com `<leader>n`.
+
+---
+
+## Lição 3 — Procurar arquivos e texto (Telescope)
+**Objetivo:** achar qualquer coisa no projeto em segundos.
+
+| Quero… | Atalho |
+|---|---|
+| Achar arquivo por nome | `<leader>ff` |
+| Procurar um **texto** no projeto (grep) | `<leader>fg` |
+| Voltar pra um arquivo já aberto (buffer) | `<leader>fb` |
+| Arquivos recentes | `<leader>fr` |
+| Procurar a **palavra sob o cursor** | `<leader>fw` |
+
+Dentro do Telescope: `<C-j>`/`<C-k>` desce/sobe na lista, `<Enter>` abre, `<Esc>` fecha.
+
+✅ **Missão:** com `<leader>fg`, procure o texto `func ` (ou `class `), pule pra um resultado, e de lá use `<leader>fw` pra encontrar onde aquela palavra aparece no projeto.
+
+---
+
+## Lição 4 — Dois arquivos lado a lado (splits)
+**Objetivo:** trabalhar com painéis um do lado do outro.
+
+| Ação | Como |
+|---|---|
+| Dividir na vertical (lado a lado) | `:vsplit` (ou `<C-w>v`) |
+| Dividir na horizontal (em cima/embaixo) | `:split` (ou `<C-w>s`) |
+| Pular entre painéis | `<C-h>` `<C-j>` `<C-k>` `<C-l>` |
+| Fechar o painel atual | `<leader>q` |
+
+Truque: abra a árvore (`<leader>n`), posicione o cursor num arquivo e tecle `s` (split vertical no neo-tree) pra abrir já ao lado.
+
+✅ **Missão:** abra um arquivo, faça `:vsplit`, abra **outro** arquivo no painel da direita com `<leader>ff`, e fique pulando entre os dois só com `<C-h>`/`<C-l>`.
+
+---
+
+## Lição 5 — Editar de verdade (o coração do Vim)
+**Objetivo:** editar com **verbo + objeto** em vez de apagar caractere por caractere.
+
+- Entrar em insert: `i` (antes) · `a` (depois) · `o` (linha abaixo) · `O` (linha acima) · `<Esc>` sai.
+- **Verbo + objeto de texto** (o que mais economiza tempo):
+  - `ciw` troca a **palavra** sob o cursor
+  - `ci"` / `ci(` / `ci{` troca o que está **dentro** de aspas/parênteses/chaves
+  - `diw`, `dd` (linha), `dt,` (apaga até a vírgula)
+  - `.` **repete** a última edição (poderosíssimo)
+- Mover linhas selecionadas: no **visual** (`V`), use `J`/`K` (atalho deste setup).
+
+✅ **Missão:** pegue uma função, renomeie 3 variáveis com `ciw` (e repita com `.`), troque o conteúdo de uma string com `ci"`, e reordene 2 linhas com `V` + `J`/`K`.
+
+---
+
+## Lição 6 — Criar (e renomear) arquivos
+**Objetivo:** criar um arquivo novo do zero, com a mão.
+
+**Pela árvore (neo-tree) — recomendado:**
+1. `<leader>n` abre a árvore.
+2. Navegue até a pasta onde quer criar.
+3. Tecle `a` → digite o nome (ex.: `treino.go`) → `<Enter>`. (`a` com `/` no fim cria pasta.)
+4. Outros: `r` renomeia, `d` apaga, `c` copia.
+
+**Pela linha de comando (alternativa):**
+- `:e caminho/novo.go` abre/cria o buffer; escreva algo e `<leader>w` salva no disco.
+
+✅ **Missão:** crie `sandbox/treino.go` pela árvore, escreva um `package main` + `func main()` com um `fmt.Println`, e salve com `<leader>w`. (Não precisa commitar — é rascunho.)
+
+---
+
+## Lição 7 — Trabalhar com código (LSP) — vira IDE aqui
+**Objetivo:** navegar e corrigir código como numa IDE. Abra um `.go`.
+
+| Ação | Atalho |
+|---|---|
+| Ir pra definição | `gd` (volta com `<C-o>`) |
+| Ver referências / implementações | `gr` / `gI` |
+| Documentação (hover) | `K` |
+| Renomear símbolo no projeto todo | `<leader>rn` |
+| Code action (deixa o LSP corrigir) | `<leader>ca` |
+| Formatar (também roda ao salvar) | `<leader>cf` |
+| Pular entre erros | `[d` / `]d` · ver o erro: `<leader>e` |
+| Símbolos do arquivo (funções) | `<leader>ds` |
+
+✅ **Missão:** apague um import de propósito → pule até o erro com `]d` → veja-o com `<leader>e` → conserte com `<leader>ca`. Depois renomeie uma função com `<leader>rn` e confira com `gr` que mudou em todo lugar.
+
+---
+
+## Lição 8 — Depurar (nvim-dap)
+**Objetivo:** rodar passo a passo. Comece num `main.go` simples.
+
+| Ação | Atalho |
+|---|---|
+| Pôr/tirar breakpoint na linha | `<leader>db` |
+| Iniciar / continuar | `<leader>dc` |
+| Step over / into / out | `<leader>do` / `<leader>di` / `<leader>dO` |
+| Abrir/fechar a UI de debug | `<leader>dt` |
+
+> **C#:** no `<leader>dc` informe a DLL (ex.: `bin/Debug/net10.0/App.dll`) — rode `dotnet build` antes.
+> **Kotlin:** informe a `mainClass` (ex.: `MainKt`). Requer projeto Gradle/Maven.
+
+✅ **Missão:** num `main.go`, ponha um breakpoint com `<leader>db` numa linha dentro de um loop, inicie com `<leader>dc`, avance com `<leader>do` e veja as variáveis na UI (`<leader>dt`).
+
+---
+
+## 📅 Progressão sugerida (2 semanas)
+- **Dias 1–3:** rode `vimtutor` (25 min, no terminal) + Aquecimento + Lições 1–2.
+- **Dias 4–6:** Lições 3–4 (buscar + splits) num projeto real.
+- **Dias 7–9:** Lição 5 (editar) — e aqui **passe a usar o nvim no dia a dia**, mesmo lento.
+- **Dias 10–12:** Lições 6–7 (criar + LSP).
+- **Dias 13–14:** Lição 8 (debug) + revisão geral.
+
+## 🏁 Checklist "já domino"
+- [ ] Abro/fecho/salvo arquivos sem mouse (Lição 1)
+- [ ] Abro e navego na árvore (Lição 2)
+- [ ] Acho arquivo e texto com Telescope (Lição 3)
+- [ ] Trabalho com dois painéis lado a lado (Lição 4)
+- [ ] Edito com `ciw`/`ci"`/`.` e movo linhas com `J`/`K` (Lição 5)
+- [ ] Crio arquivos pela árvore (Lição 6)
+- [ ] Navego e corrijo com LSP: `gd`/`gr`/`<leader>rn`/`<leader>ca` (Lição 7)
+- [ ] Coloco breakpoint e dou step no debug (Lição 8)

--- a/nvim/README.md
+++ b/nvim/README.md
@@ -3,6 +3,8 @@
 Config de Neovim como IDE para **Go**, **.NET/C#** e **Kotlin**, com integração
 ao **Claude Code** e **WakaTime**. Histórico completo e racional em [`SETUP.md`](./SETUP.md).
 
+> 🔥 Pegando prática? Siga as lições guiadas em [`PRACTICE.md`](./PRACTICE.md).
+
 ## Instalação nesta máquina
 
 Pré-requisitos: Neovim ≥ 0.11, `git`, `ripgrep`, `fd`, um compilador C (Xcode CLT no macOS)

--- a/wezterm/README.md
+++ b/wezterm/README.md
@@ -44,7 +44,7 @@ ln -sfn "$PWD/wezterm/.wezterm.lua" ~/.config/wezterm/wezterm.lua
 ### Aparência
 | Opção | Valor | Por quê |
 |---|---|---|
-| `color_scheme` | Catppuccin Mocha | Tema escuro |
+| `color_scheme` | Tokyo Night | Tema escuro — mesma paleta do starship, nvim e statusline do Claude |
 | `window_background_opacity` | 0.95 | Leve transparência |
 | `macos_window_background_blur` | 20 | Desfoca o fundo atrás da janela (combina com a transparência) |
 | `window_decorations` | `TITLE \| RESIZE` | Mantém barra de título e permite redimensionar |
@@ -89,6 +89,7 @@ ln -sfn "$PWD/wezterm/.wezterm.lua" ~/.config/wezterm/wezterm.lua
 |---|---|
 | `CMD + Enter` | Split em cima/embaixo (`SplitVertical` — novo pane **abaixo**) |
 | `CMD + Shift + Enter` | Split lado a lado (`SplitHorizontal` — novo pane **à direita**) |
+| `CMD + Alt + Enter` | Split lado a lado com o novo pane **à esquerda** |
 | `CMD + W` | Fecha o pane atual |
 | `CMD + setas` | Move o foco entre panes |
 | `CMD + Ctrl + setas` | Redimensiona o pane atual |
@@ -98,6 +99,20 @@ ln -sfn "$PWD/wezterm/.wezterm.lua" ~/.config/wezterm/wezterm.lua
 | Atalho | Ação |
 |---|---|
 | `CMD + Shift + X` | Modo de cópia: navega o histórico pelo teclado e copia sem mouse |
+
+## Status bars
+
+A config registra um handler de `update-status` com dois indicadores:
+
+- **Esquerda** — recursos da máquina (`CPU x% · MEM y%`), do
+  [`sysinfo.sh`](./sysinfo.sh) desta pasta. Usa `ps`/`memory_pressure` (macOS)
+  com cache de 4s, então cada tick é barato.
+- **Direita** — consumo do mês do Claude Code vs limite
+  (`$59/$300 · 20% · hoje $9 · proj $295`), do
+  [`../claude/usage.sh`](../claude/usage.sh). Detalhes em
+  [`../claude/README.md`](../claude/README.md).
+
+Os dois colorem por faixa de uso (verde → amarelo → laranja → vermelho).
 
 ## Glossário
 


### PR DESCRIPTION
## O que muda

Alinha CLAUDE.md, READMEs (PT+EN), READMEs de pastas e a skill `machine-bootstrap` com o estado real do repo.

**CLAUDE.md**
- Declara o escopo do projeto: **uso pessoal ou profissional**, **macOS-first** (outros SOs podem vir no futuro, mas fora de escopo agora), pensado para fork
- Nova convenção: toda mudança em `README.md` deve ser espelhada em `README-en.md` (o drift do `.npmrc` era sintoma da falta dessa regra)
- Estrutura completa: `defaultdots/`, `.claude/` (com `/setup-machine` e `/sync`), `nvim/README.md`/`PRACTICE.md`

**READMEs PT+EN**
- `claude/` e `cmux/` entram na tabela de estrutura (estavam invisíveis); slash commands documentados
- Passo do `just seed` lista os 8 arquivos reais — dizia 3 e omitia os dois do Claude Code
- Remove a promessa de "Python" na linha do mise (não está no `config.toml`)
- Aviso novo: instaladores que fazem `>> ~/.zshrc` escrevem direto no repo (efeito do symlink) — conferir `git diff` antes de commitar
- EN ganha o `.npmrc` na matriz de segurança (só existia no PT)

**Outros**
- `nvim/PRACTICE.md` versionado — o README já linkava e o link quebrava em clone novo
- `wezterm/README`: tema corrigido (Tokyo Night, não Catppuccin Mocha), status bars documentados, atalho `CMD+Alt+Enter`
- `mise/README`: inclui `npm:ccusage`
- Skill `machine-bootstrap`: composição real do bootstrap (faltava `podman-machine`) + `usage-budget`/`just ruflo`

## Verificação

- Estrutura de headings PT ↔ EN: 1:1 (20 headings, mesma ordem) ✓
- Links relativos apontam para arquivos existentes ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)