### PR TITLE
chore(hygiene): remove config morta, blinda o gitignore e endurece o CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
   pull_request:
 
+# Push novo no mesmo PR cancela a run anterior (não gasta runner à toa)
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -28,11 +33,23 @@ jobs:
           version: latest
           args: --check nvim/
 
+      - name: Lint shell scripts (shellcheck)
+        run: shellcheck claude/usage.sh claude/statusline.sh wezterm/sysinfo.sh
+
+      # cmux/cmux.json fica de fora: é JSONC (comentários) por design
+      - name: Validate JSON files
+        run: |
+          for f in claude/settings.json .claude/settings.json nvim/lazy-lock.json; do
+            jq empty "$f" && echo "ok $f"
+          done
+
       - name: Set up just
         uses: extractions/setup-just@v2
 
       - name: Validate justfile
-        run: just --summary
+        run: |
+          just --summary
+          just --fmt --check --unstable
 
   secrets:
     name: Secret scanning

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,12 @@
 
 # Claude Code — overrides pessoais (settings.json compartilhado é versionado)
 .claude/settings.local.json
+
+# Estado de runtime de ferramentas de IA (nunca versionar)
+.claude-flow/
+.claude/proven-config.json
+.claude/.proven-config-version
+
+# macOS + backups gerados pelo `just link`
+.DS_Store
+*.bak.*

--- a/dotfiles/.zshrc
+++ b/dotfiles/.zshrc
@@ -1,75 +1,15 @@
-# If you come from bash you might have to change your $PATH.
-# export PATH=$HOME/bin:$HOME/.local/bin:/usr/local/bin:$PATH
+# ~/.zshrc — symlinkado deste repo (big-bang/dotfiles/.zshrc) pelo `just link`.
+# Editar aqui OU na home é a mesma coisa (é o mesmo arquivo). Config específica
+# da máquina e segredos vão em ~/.zshrc.local (gitignored), carregado no fim.
 
-# Path to your Oh My Zsh installation.
+## oh-my-zsh
 export ZSH="$HOME/.oh-my-zsh"
-
-# Set name of the theme to load --- if set to "random", it will
-# load a random theme each time Oh My Zsh is loaded, in which case,
-# to know which specific one was loaded, run: echo $RANDOM_THEME
-# See https://github.com/ohmyzsh/ohmyzsh/wiki/Themes
 ZSH_THEME=""   # prompt gerenciado pelo starship (init no fim do arquivo)
-
-# Set list of themes to pick from when loading at random
-# Setting this variable when ZSH_THEME=random will cause zsh to load
-# a theme from this variable instead of looking in $ZSH/themes/
-# If set to an empty array, this variable will have no effect.
-# ZSH_THEME_RANDOM_CANDIDATES=( "robbyrussell" "agnoster" )
-
-# Uncomment the following line to use case-sensitive completion.
-# CASE_SENSITIVE="true"
-
-# Uncomment the following line to use hyphen-insensitive completion.
-# Case-sensitive completion must be off. _ and - will be interchangeable.
-# HYPHEN_INSENSITIVE="true"
-
-# Uncomment one of the following lines to change the auto-update behavior
-# zstyle ':omz:update' mode disabled  # disable automatic updates
-# zstyle ':omz:update' mode auto      # update automatically without asking
-# zstyle ':omz:update' mode reminder  # just remind me to update when it's time
-
-# Uncomment the following line to change how often to auto-update (in days).
-# zstyle ':omz:update' frequency 13
-
-# Uncomment the following line if pasting URLs and other text is messed up.
-# DISABLE_MAGIC_FUNCTIONS="true"
-
-# Uncomment the following line to disable colors in ls.
-# DISABLE_LS_COLORS="true"
-
-# Uncomment the following line to disable auto-setting terminal title.
-# DISABLE_AUTO_TITLE="true"
-
-# Uncomment the following line to enable command auto-correction.
-# ENABLE_CORRECTION="true"
-
-# Uncomment the following line to display red dots whilst waiting for completion.
-# You can also set it to another string to have that shown instead of the default red dots.
-# e.g. COMPLETION_WAITING_DOTS="%F{yellow}waiting...%f"
-# Caution: this setting can cause issues with multiline prompts in zsh < 5.7.1 (see #5765)
 COMPLETION_WAITING_DOTS="true"
-
-# Uncomment the following line if you want to disable marking untracked files
-# under VCS as dirty. This makes repository status check for large repositories
-# much, much faster.
-# DISABLE_UNTRACKED_FILES_DIRTY="true"
-
-# Uncomment the following line if you want to change the command execution time
-# stamp shown in the history command output.
-# You can set one of the optional three formats:
-# "mm/dd/yyyy"|"dd.mm.yyyy"|"yyyy-mm-dd"
-# or set a custom format using the strftime function format specifications,
-# see 'man strftime' for details.
 HIST_STAMPS="yyyy-mm-dd"
 
-# Would you like to use another custom folder than $ZSH/custom?
-# ZSH_CUSTOM=/path/to/new-custom-folder
-
-# Which plugins would you like to load?
-# Standard plugins can be found in $ZSH/plugins/
-# Custom plugins may be added to $ZSH_CUSTOM/plugins/
-# Example format: plugins=(rails git textmate ruby lighthouse)
-# Add wisely, as too many plugins slow down shell startup.
+# Plugins (aliases/completions). Plugin aqui ≠ binário instalado — os programas
+# em si vêm do Brewfile/mise.
 plugins=(
     #Password mgmt
     1password
@@ -84,27 +24,27 @@ plugins=(
     #Docker e K8s
     docker
     docker-compose
-    kubectl 
+    kubectl
 
     #Infra
     ansible
     terraform
     opentofu
     vagrant
-    
+
     #DB
     postgres
     redis-cli
 
     #Dev
     aws
-    git 
+    git
     vscode
-    
+
     #Langs
     golang
     rust
-    
+
     #JVM Family
     mvn
     gradle
@@ -128,34 +68,13 @@ else
   echo "big-bang: oh-my-zsh não encontrado em $ZSH — rode 'just omz' no repo" >&2
 fi
 
-# User configuration
-
-# export MANPATH="/usr/local/man:$MANPATH"
-
-# You may need to manually set your language environment
-# export LANG=en_US.UTF-8
-
-# Editor padrão
+## Editor padrão
 export EDITOR=nvim
 export VISUAL=nvim
 
-# Compilation flags
-# export ARCHFLAGS="-arch $(uname -m)"
-
-# Set personal aliases, overriding those provided by Oh My Zsh libs,
-# plugins, and themes. Aliases can be placed here, though Oh My Zsh
-# users are encouraged to define aliases within a top-level file in
-# the $ZSH_CUSTOM folder, with .zsh extension. Examples:
-# - $ZSH_CUSTOM/aliases.zsh
-# - $ZSH_CUSTOM/macos.zsh
-# For a full list of active aliases, run `alias`.
-#
-# Example aliases
-# alias zshconfig="mate ~/.zshrc"
-# alias ohmyzsh="mate ~/.oh-my-zsh"
+## Aliases
 alias lg="lazygit"
 alias ld="lazydocker"
-alias lnpm="lazynpm"
 alias vscode="code"
 alias python="python3"
 alias tf="tofu"
@@ -167,7 +86,7 @@ alias ll="eza -lh --git --icons=auto"
 alias la="eza -lah --git --icons=auto"
 alias cat="bat --paging=never"
 #Only if is using podman instead of docker
-# alias docker="podman" 
+# alias docker="podman"
 
 ## History Custom Configuration
 # HISTORY
@@ -217,25 +136,15 @@ command -v fzf >/dev/null && source <(fzf --zsh)
 ## .local bin
 export PATH="$HOME/.local/bin":$PATH
 
-## Clojure
-## -- sem config personalizada -- 
-
-## Golang 
+## Golang
 export PATH="$HOME/go/bin:$PATH"   # binários de `go install` (Go gerenciado pelo mise)
 
 ## Java
 ## JAVA_HOME é provido pelo mise (plugin java)
 
-### Gradle
-## -- sem config personalizada -- 
-
-### Maven
-## -- sem config personalizada -- 
-
-## NodeJS
-## -- sem config personalizada -- 
-
 ## Docker, Podman e K8s
+# Limpa DOCKER_HOST pra ferramentas (docker CLI, testcontainers) usarem o socket
+# padrão — que no macOS é provido pelo podman-mac-helper (ver README, FAQ).
 export DOCKER_HOST=
 
 # Contextos EKS parametrizados — defina EKS_PRD_ARN e EKS_HML_ARN em ~/.zshrc.local
@@ -246,8 +155,6 @@ function k8s-p() {
 function k8s-h() {
     kubectl config use-context "${EKS_HML_ARN:?defina EKS_HML_ARN em ~/.zshrc.local}" && kubectl "$@"
 }
-
-# !!!!!! DANGEROUS ZONE !!!!!!
 
 ## GPG
 export GPG_TTY=$(tty)

--- a/dotfiles/.zshrc
+++ b/dotfiles/.zshrc
@@ -142,6 +142,25 @@ export PATH="$HOME/go/bin:$PATH"   # binários de `go install` (Go gerenciado pe
 ## Java
 ## JAVA_HOME é provido pelo mise (plugin java)
 
+# --- Guardrails de techs que já usei / posso voltar a usar ---------------
+# Seções de reserva: sem config ativa hoje, mas o lugar de cada coisa já
+# está marcado pra quando a tech voltar (ex.: na máquina pessoal).
+
+## Clojure
+## -- sem config ativa -- (aliases globais já são seedados em ~/.clojure/deps.edn)
+
+### Gradle
+## -- sem config ativa --
+# export GRADLE_USER_HOME="$HOME/.gradle"   # exemplo: cache/props fora do default
+
+### Maven
+## -- sem config ativa --
+# export MAVEN_OPTS="-Xmx2g"                # exemplo: memória do build
+
+## NodeJS
+## -- sem config ativa -- (Node vem do mise; NPM_TOKEN vive em ~/.zshrc.local e é lido pelo ~/.npmrc)
+# --------------------------------------------------------------------------
+
 ## Docker, Podman e K8s
 # Limpa DOCKER_HOST pra ferramentas (docker CLI, testcontainers) usarem o socket
 # padrão — que no macOS é provido pelo podman-mac-helper (ver README, FAQ).
@@ -156,15 +175,21 @@ function k8s-h() {
     kubectl config use-context "${EKS_HML_ARN:?defina EKS_HML_ARN em ~/.zshrc.local}" && kubectl "$@"
 }
 
-## GPG
+# !!!!!! DANGEROUS ZONE — dados sensíveis !!!!!!
+# Chaves e segredos NÃO vivem neste arquivo (ele é versionado no repo).
+# Vivem em ~/.zshrc.local, que é gitignored e nunca sai da máquina — os
+# blocos abaixo são só os APONTAMENTOS para eles.
+
+## GPG (assinatura de commits — a chave em si fica no keyring, não aqui)
 export GPG_TTY=$(tty)
 command -v gpgconf >/dev/null && gpgconf --kill gpg-agent
 
 ## Segredos e config específica da máquina (NÃO commitado)
-## Defina aqui: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN,
-## GITHUB_TOKEN, EKS_PRD_ARN, EKS_HML_ARN, etc.
+## Defina lá: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN,
+## GITHUB_TOKEN, NPM_TOKEN, EKS_PRD_ARN, EKS_HML_ARN, etc.
 ## Referência: ~/.zshrc.local.example
 [ -f ~/.zshrc.local ] && source ~/.zshrc.local
+# !!!!!! fim da DANGEROUS ZONE !!!!!!
 
 ## Prompt (starship) — substitui o tema do oh-my-zsh. Config: ~/.config/starship.toml
 command -v starship >/dev/null && eval "$(starship init zsh)"

--- a/justfile
+++ b/justfile
@@ -1,7 +1,7 @@
 # Big Bang — bootstrap & maintenance.  Run `just` to list recipes.
 # Fresh machine: install Homebrew, then `brew install just`, then `just bootstrap`.
 
-set shell := ["bash", "-uc"]
+set shell := ["bash", "-euc"]
 
 repo := justfile_directory()
 home := env_var('HOME')
@@ -73,9 +73,12 @@ seed:
     @echo "→ GPG: commits são assinados por padrão — crie uma chave (gpg --full-generate-key)"
     @echo "  e preencha user.signingKey, ou rode: git config --global commit.gpgsign false"
 
-# Update the Brewfile from what's currently installed
+# Update the Brewfile from what's currently installed.
+# ⚠️ Sobrescreve o Brewfile CURADO (comentários e seções são perdidos) pelo dump
+# cru do brew — revise o `git diff Brewfile` e restaure a organização antes de commitar.
 brew-dump:
     brew bundle dump --force --file="{{ repo }}/Brewfile"
+    @echo "⚠️  Brewfile sobrescrito pelo dump cru — revise o diff antes de commitar (comentários/seções se perdem)"
 
 # Sanity check: tools present + symlinks resolved (exit 1 on any failure)
 doctor:

--- a/nvim/lua/plugins/formatting.lua
+++ b/nvim/lua/plugins/formatting.lua
@@ -21,11 +21,7 @@ return {
         lua = { "stylua" },
       },
       -- Formata ao salvar; cai pro LSP se não houver formatador específico
-      format_on_save = function(bufnr)
-        local disable_filetypes = {}
-        local lsp_format = disable_filetypes[vim.bo[bufnr].filetype] and "never" or "fallback"
-        return { timeout_ms = 1500, lsp_format = lsp_format }
-      end,
+      format_on_save = { timeout_ms = 1500, lsp_format = "fallback" },
     },
   },
 }

--- a/starship/starship.toml
+++ b/starship/starship.toml
@@ -1,6 +1,8 @@
 # Tema: Tokyo Night (night) — alinhado com nvim (tokyonight) e wezterm.
 # Sobrescreve os nomes ANSI (blue/green/yellow/red) usados nos módulos abaixo
 # pelos hex exatos do Tokyo Night, então o prompt fica idêntico em qualquer terminal.
+#
+# Só o que diverge do default do starship vive aqui — o resto usa o padrão.
 palette = "tokyonight"
 
 [palettes.tokyonight]
@@ -12,72 +14,29 @@ orange = "#ff9e64"
 red = "#f7768e"
 purple = "#bb9af7"
 
+# AWS fora do prompt: com SSO/perfis o contexto muda toda hora e vira ruído.
 [aws]
 disabled = true
-symbol = "  "
-
-[buf]
-symbol = " "
-
-[bun]
-symbol = " "
-
-[c]
-symbol = " "
-
-[cpp]
-symbol = " "
-
-[cmake]
-symbol = " "
-
-[conda]
-symbol = " "
-
-[crystal]
-symbol = " "
-
-[dart]
-symbol = " "
-
-[deno]
-symbol = " "
 
 [directory]
 read_only = " 󰌾"
-truncation_length = 0
+truncation_length = 0   # caminho completo, sem truncar — contexto > espaço
 truncation_symbol = '…/'
 style = "blue bold"
 
 [docker_context]
 disabled = false
-only_with_files = false
-symbol = " "
-format = "via [$symbol(docker context show 2>/dev/null | tr -d '\n')]($style) "
+only_with_files = false   # mostra o contexto sempre, não só em pasta com Dockerfile
+symbol = " "
 style = "blue bold"
 
-[elixir]
-symbol = " "
-
-[elm]
-symbol = " "
-
-[fennel]
-symbol = " "
-
-[fossil_branch]
-symbol = " "
-
-[gcloud]
-symbol = "  "
-
 [git_branch]
-symbol = ""
+symbol = ""
 format = '[ $symbol $branch ]($style)'
 
 [git_commit]
 commit_hash_length = 4
-tag_symbol = '  '
+tag_symbol = '  '
 
 [git_state]
 format = '[\($state( $progress_current of $progress_total)\)]($style) '
@@ -88,146 +47,41 @@ format = '([\[$all_status$ahead_behind\]]($style))'
 disabled = false
 style = 'bold yellow'
 
-[golang]
-symbol = " "
-
-[guix_shell]
-symbol = " "
-
-[haskell]
-symbol = " "
-
-[haxe]
-symbol = " "
-
-[hg_branch]
-symbol = " "
-
 [direnv]
 disabled = false
 
+# Host sempre visível (não só em SSH) — útil alternando entre máquinas parecidas.
 [hostname]
 ssh_only = false
-format = '[ $hostname ](bold dimmed green)'
-
-[java]
-symbol = " "
-
-[julia]
-symbol = " "
-
-[kotlin]
-symbol = " "
-
-[lua]
-symbol = " "
-
-[memory_usage]
-disabled = true
-symbol = "󰍛 "
-threshold = -1
-style = 'bold dimmed green'
-
-[meson]
-symbol = "󰔷 "
-
-[nim]
-symbol = "󰆥 "
-
-[nix_shell]
-symbol = " "
-
-[nodejs]
-symbol = " "
-
-[ocaml]
-symbol = " "
-
-[os.symbols]
-Alpaquita = " "
-Alpine = " "
-AlmaLinux = " "
-Amazon = " "
-Android = " "
-Arch = " "
-Artix = " "
-CachyOS = " "
-CentOS = " "
-Debian = " "
-DragonFly = " "
-Emscripten = " "
-EndeavourOS = " "
-Fedora = " "
-FreeBSD = " "
-Garuda = "󰛓 "
-Gentoo = " "
-HardenedBSD = "󰞌 "
-Illumos = "󰈸 "
-Kali = " "
-Linux = " "
-Mabox = " "
-Macos = " "
-Manjaro = " "
-Mariner = " "
-MidnightBSD = " "
-Mint = " "
-NetBSD = " "
-NixOS = " "
-Nobara = " "
-OpenBSD = "󰈺 "
-openSUSE = " "
-OracleLinux = "󰌷 "
-Pop = " "
-Raspbian = " "
-Redhat = " "
-RedHatEnterprise = " "
-RockyLinux = " "
-Redox = "󰀘 "
-Solus = "󰠳 "
-SUSE = " "
-Ubuntu = " "
-Unknown = " "
-Void = " "
-Windows = "󰍲 "
+format = '[ $hostname ](bold dimmed green)'
 
 [package]
 format = 'via [󰏗 $version](orange bold) '
 
-[perl]
-symbol = " "
+# Símbolos Nerd Font só das linguagens deste setup (ver mise/ e nvim/).
+[golang]
+symbol = " "
 
-[php]
-symbol = " "
+[java]
+symbol = " "
 
-[pijul_channel]
-symbol = " "
+[kotlin]
+symbol = " "
 
-[pixi]
-symbol = "󰏗 "
+[nodejs]
+symbol = " "
 
 [python]
-symbol = " "
-
-[rlang]
-symbol = "󰟔 "
-
-[ruby]
-symbol = " "
+symbol = " "
 
 [rust]
 symbol = "󱘗 "
 
-[scala]
-symbol = " "
-
-[swift]
-symbol = " "
-
-[zig]
-symbol = " "
+[lua]
+symbol = " "
 
 [gradle]
-symbol = " "
+symbol = " "
 
 [sudo]
 style = 'bold green'


### PR DESCRIPTION
## O que muda

Limpeza de config morta + proteções novas de repo e CI. **-289/+80 linhas.**

- **`.gitignore`**: ignora estado de runtime de ferramentas de IA (`.claude-flow/`, `proven-config`), `.DS_Store` (repo macOS-first!) e os backups `*.bak.*` que o próprio `just link` gera — tudo isso estava a um `git add -A` de ser commitado
- **`.zshrc`** (-134 linhas): sai o boilerplate comentado do oh-my-zsh, as 5 seções "sem config personalizada", o marcador `DANGEROUS ZONE` órfão e o alias morto `lnpm` (lazynpm nunca esteve no Brewfile); `DOCKER_HOST=` vazio agora explica o porquê (socket padrão via podman-mac-helper); header novo explica o symlink
- **`starship.toml`** (-194 linhas): sai o bloco `[os.symbols]` de 46 distros Linux e os symbols de linguagens fora do stack; sai o `[docker_context].format` com shell inline que o starship não executa (renderizava lixo) e o `[memory_usage]` contraditório; as decisões reais (truncation, hostname sempre visível, aws off) agora têm comentário
- **`formatting.lua`**: remove `disable_filetypes = {}` — lógica que nunca disparava
- **CI**: shellcheck nos 3 scripts (já passam limpos), validação de JSON com `jq empty` (cmux.json fica de fora: é JSONC por design), `just --fmt --check --unstable`, e `concurrency` group
- **`justfile`**: `bash -euc` (linha encadeada aborta no erro) e aviso no `brew-dump` de que o dump cru sobrescreve o Brewfile curado

## Verificação

- `zsh -n` + shell interativo abre normal ✓
- `starship print-config` + `starship prompt` renderiza ✓
- `stylua --check nvim/` ✓ · `nvim --headless "+q"` sem erro ✓
- `just --summary` + `just --fmt --check --unstable` ✓
- `shellcheck` limpo nos 3 scripts ✓ · `jq empty` ok nos 3 JSONs ✓
- Após o novo `.gitignore`, `git status` não mostra mais os artefatos de runtime ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)