### PR TITLE
feat(setup): setup ciente de contexto — trabalho vs pessoal

### DIFF
--- a/.claude/commands/setup-machine.md
+++ b/.claude/commands/setup-machine.md
@@ -7,6 +7,8 @@ skill **machine-bootstrap**. Confirme cada passo destrutivo antes de executar e
 
 Resumo do fluxo (a skill tem o detalhe):
 
+0. Pergunte o contexto da máquina: trabalho ou pessoal → containers (podman no
+   trabalho por licença; docker ok na pessoal) e linguagens além de Go/.NET.
 1. Garanta Homebrew e `just` (`brew install just`); instale o Homebrew se faltar.
 2. `just bootstrap` — instala o `@Brewfile`, symlinka os configs (com backup),
    confia e instala as toolchains do `mise` (`mise trust` + `mise install`) e faz o *seed* dos templates.

--- a/.claude/skills/machine-bootstrap/SKILL.md
+++ b/.claude/skills/machine-bootstrap/SKILL.md
@@ -17,6 +17,21 @@ nova pronta com o mínimo de esforço, sem expor segredos.
 
 ## Passos
 
+0. **Contexto da máquina** (pergunte ANTES do bootstrap — use AskUserQuestion)
+   O setup varia entre máquina de **trabalho** e **pessoal**. Pergunte:
+   - **Trabalho ou pessoal?** Deriva os defaults das duas perguntas seguintes.
+   - **Containers: podman ou docker?**
+     - *Trabalho* → **podman** (Docker Desktop tem licença comercial). Fluxo
+       normal: o Brewfile já traz `podman` e o bootstrap roda `just podman-machine`.
+     - *Pessoal* → **docker** é ok. Nesse caso: remova/ignore `podman` no
+       Brewfile, sugira `! brew install --cask docker` (cask pede senha), e o
+       `just podman-machine` se auto-pula quando o podman não está instalado.
+       O alias comentado `docker=podman` do `.zshrc` NÃO se aplica.
+   - **Linguagens além de Go/.NET?** (Kotlin, Java, Clojure, Node…)
+     Hoje o default cobre Go + .NET (+ Kotlin em potencial). Para as demais,
+     oriente onde ligar cada uma: toolchain no `mise/config.toml`, seção
+     guardrail correspondente no `dotfiles/.zshrc`, LSP no `nvim/` se for editar.
+
 1. **Pré-requisitos**
    - Homebrew instalado? Se não, instale (`/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`).
    - `brew install just`

--- a/Brewfile
+++ b/Brewfile
@@ -44,3 +44,5 @@ cask "visual-studio-code"  # instala também o CLI `code` no PATH
 cask "google-drive"        # Google Drive (sync)
 cask "bruno"               # client de API (alternativa a Insomnia/Postman)
 cask "studio-3t"           # GUI de MongoDB (Studio 3T Free/Community)
+# cask "docker"            # máquina PESSOAL: alternativa ao podman (no trabalho,
+                           # podman por causa da licença comercial do Docker Desktop)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,14 @@ são escopo agora** — não adicione suporte a Linux/Windows sem pedido explíc
   **só se não existirem** via `just seed` — nunca sobrescreva-os.
 - **Docs bilíngues:** toda mudança em `README.md` deve ser espelhada em
   `README-en.md` (e vice-versa) — mesma estrutura de seções, mesmo conteúdo.
+- **Convenção de pastas:** projetos vivem em `~/dev/<github-user>/<projeto>`
+  (ex.: este repo em `~/dev/<você>/big-bang`); na raiz da home (`~/`) só ficam
+  os dotfiles, via symlink/seed. Não é obrigatório (há descoberta automática e
+  `BIG_BANG_REPO`), mas é o fallback que o código assume.
+- **Contexto da máquina:** o setup varia entre trabalho e pessoal — trabalho usa
+  **podman** (licença comercial do Docker Desktop) e só Go/.NET (+Kotlin em
+  potencial); máquina pessoal pode usar **docker** e mais linguagens. Ao guiar um
+  setup, **pergunte o contexto primeiro** (passo 0 da skill *machine-bootstrap*).
 - O Lua de `nvim/` é formatado com `stylua` (o CI checa). Rode `stylua nvim/` antes de commitar.
 - **Não dê push direto na `main`.** Trabalhe em branch e abra PR com `just pr` (usa o `gh`).
 - **Uma branch por escopo.** Antes de começar qualquer trabalho cujo assunto seja

--- a/README-en.md
+++ b/README-en.md
@@ -88,6 +88,7 @@ committed secrets — only *templates* — but several defaults are mine:
 | **Machine secrets** | `~/.zshrc.local` (after `just seed`) | `AWS_*`, `GITHUB_TOKEN`, EKS ARNs, WakaTime key — see [`.zshrc.local.example`](./dotfiles/.zshrc.local.example) |
 | **WakaTime** | `~/.wakatime.cfg` | your API key (optional; remove if unused) |
 | **Packages** | [`Brewfile`](./Brewfile) | add/remove apps and CLIs to taste |
+| **Containers (work vs personal)** | [`Brewfile`](./Brewfile) + bootstrap | at **work**: podman (Docker Desktop has a commercial license); on a **personal machine**: docker is fine — swap `brew "podman"` for the `docker` cask (commented in the Brewfile) and `just podman-machine` skips itself |
 | **Editor languages** | [`nvim/`](./nvim) | Neovim ships ready for **Go, .NET/C# and Kotlin**; adapt the LSPs to your stack |
 | **Toolchains** | [`mise/config.toml`](./mise/config.toml) | Go/Java/Node/… versions that get installed |
 | **Clone path** | nothing, if you use `just seed`/`just link` | the Claude statusline ([`claude/settings.json`](./claude/settings.json)) and the WezTerm status discover the clone by themselves (fallback: the `~/dev/<github-user>/big-bang` convention); if something fails, set `BIG_BANG_REPO` in `~/.zshrc.local` |

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ tem segredo versionado — só *templates* — mas vários defaults são meus:
 | **Segredos da máquina** | `~/.zshrc.local` (após `just seed`) | `AWS_*`, `GITHUB_TOKEN`, ARNs de EKS, chave do WakaTime — veja [`.zshrc.local.example`](./dotfiles/.zshrc.local.example) |
 | **WakaTime** | `~/.wakatime.cfg` | a sua API key (opcional; remova se não usa) |
 | **Pacotes** | [`Brewfile`](./Brewfile) | tire/ponha apps e CLIs conforme o seu gosto |
+| **Containers (trabalho vs pessoal)** | [`Brewfile`](./Brewfile) + bootstrap | no **trabalho**: podman (Docker Desktop tem licença comercial); na **máquina pessoal**: docker é ok — troque `brew "podman"` pelo cask `docker` (comentado no Brewfile) e o `just podman-machine` se auto-pula |
 | **Linguagens do editor** | [`nvim/`](./nvim) | o Neovim vem pronto pra **Go, .NET/C# e Kotlin**; adapte os LSPs ao seu stack |
 | **Toolchains** | [`mise/config.toml`](./mise/config.toml) | versões de Go/Java/Node/… que serão instaladas |
 | **Caminho do clone** | nenhum, se usar `just seed`/`just link` | o statusline do Claude ([`claude/settings.json`](./claude/settings.json)) e o status do WezTerm descobrem o clone sozinhos (fallback: convenção `~/dev/<github-user>/big-bang`); se algo falhar, defina `BIG_BANG_REPO` no `~/.zshrc.local` |

--- a/justfile
+++ b/justfile
@@ -34,9 +34,13 @@ mise-install:
     mise install
 
 # Init + start the podman VM (macOS needs a Linux VM to run containers; idempotent)
+# Sem podman instalado (ex.: máquina pessoal usando docker), pula sem quebrar o bootstrap.
 podman-machine:
     #!/usr/bin/env bash
     set -euo pipefail
+    if ! command -v podman &>/dev/null; then
+      echo "skip   podman não instalado — pulando a VM (usando docker? ok; ver README)"; exit 0
+    fi
     if ! podman machine inspect podman-machine-default &>/dev/null; then
       echo "→ creating podman machine"; podman machine init
     fi


### PR DESCRIPTION
## O que muda

O setup assumia um contexto único (o da máquina de trabalho: podman, Go/.NET). Agora ele **pergunta o contexto** e se adapta — trabalho vs máquina pessoal.

- **Skill `machine-bootstrap`**: novo **passo 0 — Contexto da máquina**, perguntado antes do bootstrap:
  - Trabalho ou pessoal?
  - Containers: **podman** (trabalho — Docker Desktop tem licença comercial) ou **docker** (ok na pessoal)? No caso docker: ignora o podman do Brewfile, sugere o cask, e o `podman-machine` se auto-pula.
  - Linguagens além de Go/.NET? (Kotlin/Java/Clojure/Node…) — orienta onde ligar cada uma: toolchain no `mise/config.toml`, seção guardrail do `.zshrc`, LSP no nvim.
- **`/setup-machine`**: resumo do fluxo ganha o passo 0.
- **`justfile`**: `podman-machine` sai 0 com aviso quando o podman não está instalado (antes: `set -e` derrubava o bootstrap inteiro) — o `just bootstrap` único funciona nos dois contextos.
- **Brewfile**: `cask "docker"` comentado como alternativa de máquina pessoal, com o porquê.
- **READMEs (PT+EN)**: linha "Containers (trabalho vs pessoal)" na tabela "Faça seu fork".
- **CLAUDE.md**: convenção de pastas `~/dev/<github-user>/<projeto>` (pendência combinada no PR #52, que o #53 não pegou) + regra de perguntar o contexto no setup.

## Verificação

- `just --summary` ✓ · `brew bundle list` parseia o Brewfile ✓
- `just podman-machine` com podman fora do PATH: `skip ... exit 0` ✓ (testado)
- Paridade PT↔EN das tabelas ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)