### PR TITLE
feat(brewfile): adiciona o CLI do argocd ao baseline

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -31,6 +31,7 @@ brew "pre-commit"      # hooks de qualidade locais (pre-commit install; ver .pre
 # --- Cloud / infra ---
 brew "awscli"
 brew "kubernetes-cli"  # kubectl
+brew "argocd"          # GitOps CD p/ Kubernetes (ArgoCD) — vale trabalho e casa
 brew "opentofu"
 brew "ansible"         # ad-hoc only; remove if you don't use it
 brew "podman"          # container engine (Mac: roda via `podman machine`)

--- a/README-en.md
+++ b/README-en.md
@@ -205,7 +205,7 @@ Each folder has its own `README.md`. Root files worth knowing:
 - **Packages:** [Homebrew](https://brew.sh/) (see [`Brewfile`](./Brewfile)).
 - **Shell:** zsh + oh-my-zsh, **Starship** prompt.
 - **Editor:** Neovim (see [`nvim/`](./nvim)).
-- **Day-to-day CLIs:** lazygit, lazydocker, fzf, bat, eza, awscli, kubectl, opentofu.
+- **Day-to-day CLIs:** lazygit, lazydocker, fzf, bat, eza, awscli, kubectl, argocd, opentofu.
 
 ## How it works under the hood
 

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Cada pasta tem o seu próprio `README.md`. Arquivos da raiz que vale conhecer:
 - **Pacotes:** [Homebrew](https://brew.sh/) (veja o [`Brewfile`](./Brewfile)).
 - **Shell:** zsh + oh-my-zsh, prompt **Starship**.
 - **Editor:** Neovim (veja [`nvim/`](./nvim)).
-- **CLIs do dia a dia:** lazygit, lazydocker, fzf, bat, eza, awscli, kubectl, opentofu.
+- **CLIs do dia a dia:** lazygit, lazydocker, fzf, bat, eza, awscli, kubectl, argocd, opentofu.
 
 ## Como funciona por dentro
 


### PR DESCRIPTION
argocd (GitOps CD p/ Kubernetes) entra na seção Cloud/infra do Brewfile,
ativo para todos os setups — vale tanto no contexto de trabalho quanto no
pessoal. READMEs (pt/en) espelhados na lista de CLIs do dia a dia.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
